### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,6 +4,9 @@ on:
   push:
   pull_request:
 
+permissions:
+  contents: read
+
 jobs:
   test:
     strategy:


### PR DESCRIPTION
Potential fix for [https://github.com/Strategic-Automation/violin/security/code-scanning/3](https://github.com/Strategic-Automation/violin/security/code-scanning/3)

To fix this, add an explicit `permissions` block to the workflow so `GITHUB_TOKEN` is least-privileged by default.

Best single fix (without changing functionality): in `.github/workflows/ci.yml`, add a root-level permissions stanza right after the `on` trigger section (before `jobs`) with:

- `contents: read`

This applies to all jobs unless overridden and is sufficient for the shown steps (`actions/checkout`, dependency install, lint/test commands). No imports, methods, or extra definitions are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
