### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -4,6 +4,8 @@ on:
     branches: [master]
   pull_request:
     branches: [master]
+permissions:
+  contents: read
 jobs:
   yaml-lint:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/Strategic-Automation/violin/security/code-scanning/2](https://github.com/Strategic-Automation/violin/security/code-scanning/2)

Add an explicit `permissions` block to the workflow so `GITHUB_TOKEN` is least-privileged by default.

Best fix here: set workflow-level permissions right after `on` (before `jobs`) with:

- `contents: read`

This preserves existing behavior (checkout and read-only linting) while preventing unintended write scopes if repo/org defaults change.  
File to edit: `.github/workflows/lint.yml` in the top-level section between the trigger config and `jobs:`.  
No imports, methods, or extra definitions are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
