### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/guard-check.yml
+++ b/.github/workflows/guard-check.yml
@@ -4,6 +4,8 @@ on:
     branches: [master, dev]
   pull_request:
     branches: [master, dev]
+permissions:
+  contents: read
 jobs:
   guard-check:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/Strategic-Automation/violin/security/code-scanning/1](https://github.com/Strategic-Automation/violin/security/code-scanning/1)

Add an explicit `permissions` block to the workflow so token scope is constrained by configuration rather than defaults.

Best fix here: add a root-level workflow permission block with `contents: read` (minimal needed for `actions/checkout` and read-only repo access). This applies to all jobs unless overridden and does not change the existing workflow logic.

**File to edit:** `.github/workflows/guard-check.yml`  
**Change region:** near the top-level keys, right after `on:` block and before `jobs:`.  
**No new imports, methods, or dependencies are required.**


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
