### PR TITLE
Upgrade pytest for CVE-2025-71176 (v2.0.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 2.0.1
+
+- Upgraded the pytest development dependency to 9.0.3 or later to address CVE-2025-71176 insecure temporary-directory handling.
+
 ## 2.0.0
 
 - Added model-visible `violin_status` diagnostics, phase-aware 10/20-command sync windows, a 350-iteration profile budget, and atomic `violin_review_batch` reconciliation with optional receipt-backed finding output.

--- a/distribution.yaml
+++ b/distribution.yaml
@@ -1,6 +1,6 @@
 # violin - supervised agentic Hermes pentest profile
 name: violin
-version: 2.0.0
+version: 2.0.1
 description: "A supervised agentic Hermes penetration testing profile for authorised Kali/Parrot-based security assessment, reconnaissance, exploit validation, and reporting workflows."
 hermes_requires: ">=0.18.0"
 author: "Violin contributors"

--- a/plugins/violin_guard/plugin.yaml
+++ b/plugins/violin_guard/plugin.yaml
@@ -1,5 +1,5 @@
 name: violin-guard
-version: "2.0.0"
+version: "2.0.1"
 description: Typed scope guards and an execute-and-record boundary with bounded synchronization windows.
 kind: standalone
 provides_tools:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,13 +1,13 @@
 [project]
 name = "violin"
-version = "2.0.0"
+version = "2.0.1"
 description = "Supervised agentic Hermes penetration-testing profile"
 requires-python = ">=3.11"
 dependencies = ["filelock>=3.13,<4"]
 
 [dependency-groups]
 dev = [
-    "pytest>=8.0,<9",
+    "pytest>=9.0.3,<10",
     "pyyaml>=6.0,<7",
     "ruff>=0.11,<0.12",
 ]

--- a/uv.lock
+++ b/uv.lock
@@ -58,7 +58,7 @@ wheels = [
 
 [[package]]
 name = "pytest"
-version = "8.4.2"
+version = "9.1.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "colorama", marker = "sys_platform == 'win32'" },
@@ -67,9 +67,9 @@ dependencies = [
     { name = "pluggy" },
     { name = "pygments" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/a3/5c/00a0e072241553e1a7496d638deababa67c5058571567b92a7eaa258397c/pytest-8.4.2.tar.gz", hash = "sha256:86c0d0b93306b961d58d62a4db4879f27fe25513d4b969df351abdddb3c30e01", size = 1519618, upload-time = "2025-09-04T14:34:22.711Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/e4/47/b9efed96c114afcfa3c9d3fe98a76a1d14c74a9e266d397cf6eb64be5e01/pytest-9.1.1.tar.gz", hash = "sha256:1088fbde8f2b49d95a549a195707afa7a76a3ce9bcadc26b6d71f0ffda5fe313", size = 1636369, upload-time = "2026-06-19T10:58:32.857Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/a8/a4/20da314d277121d6534b3a980b29035dcd51e6744bd79075a6ce8fa4eb8d/pytest-8.4.2-py3-none-any.whl", hash = "sha256:872f880de3fc3a5bdc88a11b39c9710c3497a547cfa9320bc3c5e62fbf272e79", size = 365750, upload-time = "2025-09-04T14:34:20.226Z" },
+    { url = "https://files.pythonhosted.org/packages/24/25/1de2678b631f5a49215c6c96fff41ba892b0a34df68d6d80292b1b48aa7f/pytest-9.1.1-py3-none-any.whl", hash = "sha256:37a86b45efb9a47a61a36449063e8e18d0cab3161329fc099eb21783169c4f0c", size = 386536, upload-time = "2026-06-19T10:58:31.347Z" },
 ]
 
 [[package]]
@@ -154,7 +154,7 @@ wheels = [
 
 [[package]]
 name = "violin"
-version = "2.0.0"
+version = "2.0.1"
 source = { virtual = "." }
 dependencies = [
     { name = "filelock" },
@@ -172,7 +172,7 @@ requires-dist = [{ name = "filelock", specifier = ">=3.13,<4" }]
 
 [package.metadata.requires-dev]
 dev = [
-    { name = "pytest", specifier = ">=8.0,<9" },
+    { name = "pytest", specifier = ">=9.0.3,<10" },
     { name = "pyyaml", specifier = ">=6.0,<7" },
     { name = "ruff", specifier = ">=0.11,<0.12" },
 ]


### PR DESCRIPTION
## What changed

- raise the development dependency floor to `pytest>=9.0.3,<10`
- refresh `uv.lock` to pytest 9.1.1
- bump Violin, the distribution manifest, and the guard plugin to 2.0.1
- document the security patch in `CHANGELOG.md`

## Why

The previous lockfile resolved pytest 8.4.2, which is affected by CVE-2025-71176 (insecure temporary-directory handling). This updates the development/test toolchain to a patched release.

Security alert: https://github.com/Strategic-Automation/violin/security/dependabot/1

## Impact

This is a patch release. Runtime dependencies and guard behavior are unchanged; the change affects only the development/test dependency and release metadata.

## Checks

- `uv run pytest tests/guard -q --basetemp .pytest-pytest903-guard-rerun` — 122 passed
- `uv run ruff check .`
- `uv run ruff format --check .`
- `git diff --check`
- `python scripts\\violin_guard.py check-release`