### PR TITLE
Restrict GitHub Actions token permissions (v2.0.2)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,6 +4,9 @@ on:
   push:
   pull_request:
 
+permissions:
+  contents: read
+
 jobs:
   test:
     strategy:

--- a/.github/workflows/guard-check.yml
+++ b/.github/workflows/guard-check.yml
@@ -4,6 +4,10 @@ on:
     branches: [master, dev]
   pull_request:
     branches: [master, dev]
+
+permissions:
+  contents: read
+
 jobs:
   guard-check:
     runs-on: ubuntu-latest

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -4,6 +4,10 @@ on:
     branches: [master]
   pull_request:
     branches: [master]
+
+permissions:
+  contents: read
+
 jobs:
   yaml-lint:
     runs-on: ubuntu-latest

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 2.0.2
+
+- Restricted all GitHub Actions workflow tokens to read-only repository contents, resolving the three least-privilege code-scanning alerts without changing workflow behavior.
+
 ## 2.0.1
 
 - Upgraded the pytest development dependency to 9.0.3 or later to address CVE-2025-71176 insecure temporary-directory handling.

--- a/distribution.yaml
+++ b/distribution.yaml
@@ -1,6 +1,6 @@
 # violin - supervised agentic Hermes pentest profile
 name: violin
-version: 2.0.1
+version: 2.0.2
 description: "A supervised agentic Hermes penetration testing profile for authorised Kali/Parrot-based security assessment, reconnaissance, exploit validation, and reporting workflows."
 hermes_requires: ">=0.18.0"
 author: "Violin contributors"

--- a/plugins/violin_guard/plugin.yaml
+++ b/plugins/violin_guard/plugin.yaml
@@ -1,5 +1,5 @@
 name: violin-guard
-version: "2.0.1"
+version: "2.0.2"
 description: Typed scope guards and an execute-and-record boundary with bounded synchronization windows.
 kind: standalone
 provides_tools:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "violin"
-version = "2.0.1"
+version = "2.0.2"
 description = "Supervised agentic Hermes penetration-testing profile"
 requires-python = ">=3.11"
 dependencies = ["filelock>=3.13,<4"]

--- a/uv.lock
+++ b/uv.lock
@@ -154,7 +154,7 @@ wheels = [
 
 [[package]]
 name = "violin"
-version = "2.0.1"
+version = "2.0.2"
 source = { virtual = "." }
 dependencies = [
     { name = "filelock" },


### PR DESCRIPTION
## What changed

- add workflow-level `permissions: contents: read` to Violin CI
- add the same least-privilege token scope to the YAML lint and guard-check workflows
- bump Violin, the distribution manifest, and the guard plugin to 2.0.2
- document the security hardening in `CHANGELOG.md`

## Why

All three workflows inherited repository or organization defaults for `GITHUB_TOKEN`. Explicit read-only content access preserves their existing checkout, lint, and test behavior while preventing unintended write scopes if those defaults change.

This consolidated patch supersedes #5, #6, and #7 and addresses code-scanning alerts 1–3.

## Impact

This is a patch release. Workflow logic and runtime behavior are unchanged; only the GitHub Actions token scope is reduced.

## Checks

- parsed all three workflow YAML files with `yaml.BaseLoader`
- asserted every workflow has exactly `permissions.contents: read`
- `uv run ruff check .`
- `uv run ruff format --check .`
- `git diff --check`
- `python scripts\\violin_guard.py check-release`