### PR TITLE
Block secondary-only primary targets (v2.0.4)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 2.0.4
+
+- Hard-blocked callback and research endpoints when supplied as primary assessment targets while preserving their approved secondary-only use, including burst execution.
+
 ## 2.0.3
 
 - Fixed raw-terminal compound-command classification so every pipeline, logical, semicolon, and newline segment is checked independently, and package/source exemptions require every URL in the segment to use an approved source host.

--- a/distribution.yaml
+++ b/distribution.yaml
@@ -1,6 +1,6 @@
 # violin - supervised agentic Hermes pentest profile
 name: violin
-version: 2.0.3
+version: 2.0.4
 description: "A supervised agentic Hermes penetration testing profile for authorised Kali/Parrot-based security assessment, reconnaissance, exploit validation, and reporting workflows."
 hermes_requires: ">=0.18.0"
 author: "Violin contributors"

--- a/plugins/violin_guard/plugin.yaml
+++ b/plugins/violin_guard/plugin.yaml
@@ -1,5 +1,5 @@
 name: violin-guard
-version: "2.0.3"
+version: "2.0.4"
 description: Typed scope guards and an execute-and-record boundary with bounded synchronization windows.
 kind: standalone
 provides_tools:

--- a/plugins/violin_guard/targets.py
+++ b/plugins/violin_guard/targets.py
@@ -78,9 +78,16 @@ class _TargetPolicy:
             candidate, self.allowed_networks
         )
 
+    def is_secondary_only(self, candidate: str) -> bool:
+        return _matches_host(candidate, self.callback_hosts | self.research_hosts)
+
     def check_primary(self, candidate: str, result: TargetCheckResult) -> None:
         if self.is_excluded(candidate):
             result.errors.append(f"excluded target {candidate} must not be touched")
+        elif self.is_secondary_only(candidate):
+            result.errors.append(
+                f"secondary-only endpoint {candidate} must not be used as a primary target"
+            )
         elif self.is_assessment_target(candidate):
             return
         elif _is_ip_network(candidate):
@@ -96,9 +103,7 @@ class _TargetPolicy:
     def check_secondary(self, candidate: str, result: TargetCheckResult) -> None:
         if self.is_excluded(candidate):
             result.errors.append(f"excluded target {candidate} must not be touched")
-        elif self.is_assessment_target(candidate) or candidate in (
-            self.callback_hosts | self.research_hosts
-        ):
+        elif self.is_assessment_target(candidate) or self.is_secondary_only(candidate):
             return
         elif _is_ip_network(candidate):
             result.errors.append(f"out-of-scope target {candidate} (not present in scope.yaml)")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "violin"
-version = "2.0.3"
+version = "2.0.4"
 description = "Supervised agentic Hermes penetration-testing profile"
 requires-python = ">=3.11"
 dependencies = ["filelock>=3.13,<4"]

--- a/tests/guard/guards/test_scope_authorization.py
+++ b/tests/guard/guards/test_scope_authorization.py
@@ -20,6 +20,7 @@ def _write_scope(path: Path, *, confirmed: bool = True, callback_hosts: str = "1
   domains: [allowed.example]
 assessment_hosts:
   callback_hosts: [{callback_hosts}]
+research_hosts: [github.com, 192.0.2.10]
 exclusions:
   ip_addresses: [10.10.10.99]
   cidrs: [2001:db8:dead::/48]
@@ -102,7 +103,7 @@ def test_legacy_descriptive_target_normalises_to_host() -> None:
 
 def test_callback_hosts_are_secondary_only_and_exclusions_still_win(tmp_path: Path) -> None:
     scope = tmp_path / "scope.yaml"
-    _write_scope(scope, callback_hosts="10.10.14.5, 10.10.10.99")
+    _write_scope(scope, callback_hosts="10.10.14.5, listener.example, 10.10.10.99")
 
     callback = check_scope_targets(
         scope,
@@ -112,6 +113,13 @@ def test_callback_hosts_are_secondary_only_and_exclusions_still_win(tmp_path: Pa
     assert not callback.errors
     assert not callback.warnings
 
+    for host in ("listener.example", "github.com"):
+        secondary = check_scope_targets(
+            scope, f"curl https://{host}/status", primary_target="10.10.10.10"
+        )
+        assert not secondary.errors
+        assert not secondary.warnings
+
     unconfigured = check_scope_targets(
         scope, "bash -c 'echo ready > /dev/tcp/10.10.14.6/4444'", primary_target="10.10.10.10"
     )
@@ -120,7 +128,13 @@ def test_callback_hosts_are_secondary_only_and_exclusions_still_win(tmp_path: Pa
     callback_as_primary = check_scope_targets(
         scope, "nc -l -v -s 10.10.14.5 4444", primary_target="10.10.14.5"
     )
-    assert any("10.10.14.5" in error for error in callback_as_primary.errors)
+    assert any(
+        "secondary-only endpoint 10.10.14.5" in error for error in callback_as_primary.errors
+    )
+
+    for host in ("listener.example", "github.com", "192.0.2.10"):
+        primary = check_scope_targets(scope, f"curl https://{host}", primary_target=host)
+        assert any(f"secondary-only endpoint {host}" in error for error in primary.errors)
 
     excluded = check_scope_targets(
         scope, "nc -l -v -s 10.10.10.99 4444", primary_target="10.10.10.10"

--- a/tests/guard/state/test_burst_and_target.py
+++ b/tests/guard/state/test_burst_and_target.py
@@ -30,6 +30,9 @@ _SCOPE = """targets:
   roles:
     web: 10.10.10.10
 exclusions: {}
+assessment_hosts:
+  callback_hosts: [listener.example]
+research_hosts: [github.com]
 authorized_parties: ["test owner"]
 authorisation:
   confirmed: true
@@ -215,6 +218,30 @@ def test_exec_burst_clean_review_or_approved(eng, monkeypatch):
     assert len(rec["commands"]) == 2
     # Only the LAST command arms the gate -> exactly one pending-sync lock.
     assert state.has_pending_sync(str(eng)) is not None
+
+
+@pytest.mark.parametrize("secondary_only_host", ["listener.example", "github.com"])
+def test_exec_burst_denies_secondary_only_primary_target(eng, monkeypatch, secondary_only_host):
+    rec = _patch_burst(monkeypatch, str(eng))
+    data = json.loads(
+        service.handle_exec_burst(
+            {
+                "eng_dir": str(eng),
+                "scope": str(eng / "scope" / "scope.yaml"),
+                "phase": "recon",
+                "commands": [f"curl https://{secondary_only_host}"],
+                "target": secondary_only_host,
+                "session_id": "ts",
+                "skill_loaded_file": str(eng / "state" / ".skill-loaded-ts"),
+                "label": "secondary-only-primary",
+            }
+        )
+    )
+
+    assert data["status"] == "denied"
+    assert data["executed"] == 0
+    assert "secondary-only endpoint" in data["reason"]
+    assert rec["commands"] == []
 
 
 def test_exec_burst_fail_closed_on_blocked_command(eng, monkeypatch):

--- a/uv.lock
+++ b/uv.lock
@@ -154,7 +154,7 @@ wheels = [
 
 [[package]]
 name = "violin"
-version = "2.0.3"
+version = "2.0.4"
 source = { virtual = "." }
 dependencies = [
     { name = "filelock" },


### PR DESCRIPTION
## What changed

- classify callback and research endpoints through one secondary-only policy predicate
- hard-block those endpoints when supplied as the primary assessment target
- preserve approved callback and research use as secondary endpoints
- add hostname, IP, wildcard-compatible, and burst fail-closed regressions
- bump the patch release to `2.0.4` and update release metadata and the changelog

## Why

Callback and research hostnames previously fell through to the generic unknown-host warning when used as the primary target. Burst execution can proceed through review warnings, so a secondary-only endpoint could receive assessment traffic.

## Impact

Callback and research endpoints now fail closed before execution when promoted to primary targets. In-scope assessment targets and approved secondary endpoint use are unchanged.

## Validation

- `uv run pytest tests/guard/guards/test_scope_authorization.py tests/guard/state/test_burst_and_target.py -q --basetemp .pytest-issue2-v204-focused` — 31 passed
- `uv run ruff check .`
- `uv run ruff format --check .`
- `git diff --check`
- `python scripts\\violin_guard.py check-release`

## Tracking

Closes #2