### PR TITLE
Fix exact-repeat history parsing (v2.0.5)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 2.0.5
+
+- Restored exact-repeat detection for execution history entries with receipt paths and added unambiguous command-length metadata while retaining compatibility with existing history files.
+
 ## 2.0.4
 
 - Hard-blocked callback and research endpoints when supplied as primary assessment targets while preserving their approved secondary-only use, including burst execution.

--- a/distribution.yaml
+++ b/distribution.yaml
@@ -1,6 +1,6 @@
 # violin - supervised agentic Hermes pentest profile
 name: violin
-version: 2.0.4
+version: 2.0.5
 description: "A supervised agentic Hermes penetration testing profile for authorised Kali/Parrot-based security assessment, reconnaissance, exploit validation, and reporting workflows."
 hermes_requires: ">=0.18.0"
 author: "Violin contributors"

--- a/plugins/violin_guard/history.py
+++ b/plugins/violin_guard/history.py
@@ -12,6 +12,10 @@ from pathlib import Path
 
 from .state import lock_file, resolve_eng_dir
 
+_COMMAND_MARKER = " | command="
+_COMMAND_LENGTH_MARKER = " | command_length="
+_RECEIPT_MARKER = " | receipt="
+
 
 def _history_path(eng_dir: str | Path) -> Path:
     return resolve_eng_dir(eng_dir) / "state" / "history.md"
@@ -28,9 +32,12 @@ def append_history(
     path = _history_path(eng_dir)
     path.parent.mkdir(parents=True, exist_ok=True)
     stamp = datetime.now(UTC).isoformat().replace("+00:00", "Z")
-    line = f"- {stamp} | phase={phase} | exit_code={exit_code} | command={command}"
+    line = (
+        f"- {stamp} | phase={phase} | exit_code={exit_code} | command={command}"
+        f"{_COMMAND_LENGTH_MARKER}{len(command)}"
+    )
     if receipt_path:
-        line += f" | receipt={receipt_path}"
+        line += f"{_RECEIPT_MARKER}{receipt_path}"
     with lock_file(path), path.open("a", encoding="utf-8") as handle:
         handle.write(line + "\n")
 
@@ -43,11 +50,31 @@ def history_contains(eng_dir: str | Path, command: str) -> bool:
     hist = _history_path(eng_dir)
     if not hist.exists():
         return False
-    marker = f" | command={command}"
     for line in hist.read_text(encoding="utf-8").splitlines():
-        if line.endswith(marker) or f"{marker} | receipt=" in line:
+        if _recorded_command(line) == command:
             return True
     return False
+
+
+def _recorded_command(line: str) -> str | None:
+    """Read one command field, including legacy records without a length."""
+
+    if _COMMAND_MARKER not in line:
+        return None
+    payload = line.split(_COMMAND_MARKER, 1)[1]
+    command, marker, metadata = payload.rpartition(_COMMAND_LENGTH_MARKER)
+    if marker:
+        length_text = metadata.split(_RECEIPT_MARKER, 1)[0]
+        try:
+            expected_length = int(length_text)
+        except ValueError:
+            pass
+        else:
+            if expected_length >= 0 and len(command) == expected_length:
+                return command
+
+    command, marker, _receipt = payload.rpartition(_RECEIPT_MARKER)
+    return command if marker else payload
 
 
 def check_history_staleness(
@@ -77,8 +104,7 @@ def check_history_staleness(
     # that field exactly instead of using substring matching, which can reject
     # a command merely because it contains the previous command text.
     last_line = lines[-1]
-    marker = " | command="
-    recorded_command = last_line.split(marker, 1)[1] if marker in last_line else None
+    recorded_command = _recorded_command(last_line)
     if recorded_command == command and not allow_pending_repeat:
         errors.append(
             f"command appears to be an exact repeat of the last recorded command: {last_line}"

--- a/plugins/violin_guard/plugin.yaml
+++ b/plugins/violin_guard/plugin.yaml
@@ -1,5 +1,5 @@
 name: violin-guard
-version: "2.0.4"
+version: "2.0.5"
 description: Typed scope guards and an execute-and-record boundary with bounded synchronization windows.
 kind: standalone
 provides_tools:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "violin"
-version = "2.0.4"
+version = "2.0.5"
 description = "Supervised agentic Hermes penetration-testing profile"
 requires-python = ">=3.11"
 dependencies = ["filelock>=3.13,<4"]

--- a/tests/guard/guards/test_history_staleness.py
+++ b/tests/guard/guards/test_history_staleness.py
@@ -2,22 +2,38 @@
 
 from pathlib import Path
 
-from plugins.violin_guard.history import check_history_staleness
+from plugins.violin_guard.history import append_history, check_history_staleness, history_contains
 
 
 def test_history_deduplication_compares_the_recorded_command_field(tmp_path: Path) -> None:
     history = tmp_path / "state" / "history.md"
     history.parent.mkdir()
-    history.write_text(
-        "- 2026-07-14T10:00:00Z | phase=RECON | exit_code=0 | command=echo done\n",
-        encoding="utf-8",
-    )
+    for suffix in ("", " | receipt=evidence/executions/test.json"):
+        history.write_text(
+            f"- 2026-07-14T10:00:00Z | phase=RECON | exit_code=0 | command=echo done{suffix}\n",
+            encoding="utf-8",
+        )
 
-    errors, _, _ = check_history_staleness(tmp_path, "echo")
-    assert not errors
+        errors, _, _ = check_history_staleness(tmp_path, "echo")
+        assert not errors
 
-    errors, _, _ = check_history_staleness(tmp_path, "echo done")
+        errors, _, _ = check_history_staleness(tmp_path, "echo done")
+        assert errors
+
+
+def test_written_history_uses_command_length_for_unambiguous_receipt_parsing(
+    tmp_path: Path,
+) -> None:
+    command = "printf 'value | receipt=fake | command_length=1'"
+    append_history(tmp_path, command, "RECON", 0, "evidence/executions/test.json")
+
+    errors, _, _ = check_history_staleness(tmp_path, command)
     assert errors
+    assert history_contains(tmp_path, command)
+
+    errors, _, infos = check_history_staleness(tmp_path, command, allow_pending_repeat=True)
+    assert not errors
+    assert any("pending batch" in info for info in infos)
 
 
 def test_malformed_history_line_does_not_create_a_false_repeat(tmp_path: Path) -> None:

--- a/uv.lock
+++ b/uv.lock
@@ -154,7 +154,7 @@ wheels = [
 
 [[package]]
 name = "violin"
-version = "2.0.4"
+version = "2.0.5"
 source = { virtual = "." }
 dependencies = [
     { name = "filelock" },


### PR DESCRIPTION
## What changed

- parse recorded commands through one exact history-field helper
- strip optional receipt metadata from legacy history records
- add command-length metadata to new records so command delimiters remain unambiguous
- use the same parser for exact-repeat and pending-batch history checks
- retain pending-repeat recovery behavior
- bump the patch release to `2.0.5` and update release metadata and the changelog

## Why

Executor-written history entries append `| receipt=...` after the command. The repeat checker previously compared the requested command with the entire remainder of the line, so normal receipt-backed executions were never recognized as exact repeats.

## Impact

Immediate unchanged retries are blocked again for both legacy and new history records. Commands that only contain another command as a substring remain allowed, and explicitly approved pending-batch reconciliation remains available.

## Validation

- `uv run pytest tests/guard/guards/test_history_staleness.py tests/guard/state/test_a1_a15_regressions.py::test_pending_batch_repeat_is_allowed_for_recovery tests/guard/state/test_batch_integrity.py -q --basetemp .pytest-issue3-v205-focused` — 9 passed
- `uv run ruff check .`
- `uv run ruff format --check .`
- `git diff --check`
- `python scripts\\violin_guard.py check-release`

## Tracking

Closes #3