### PR TITLE
Resolve CodeQL standard quality findings (v2.0.6)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 2.0.6
+
+- Resolved the current CodeQL standard quality findings by making intentional exception fallbacks explicit and removing unused test and hypothesis variables.
+
 ## 2.0.5
 
 - Restored exact-repeat detection for execution history entries with receipt paths and added unambiguous command-length metadata while retaining compatibility with existing history files.

--- a/distribution.yaml
+++ b/distribution.yaml
@@ -1,6 +1,6 @@
 # violin - supervised agentic Hermes pentest profile
 name: violin
-version: 2.0.5
+version: 2.0.6
 description: "A supervised agentic Hermes penetration testing profile for authorised Kali/Parrot-based security assessment, reconnaissance, exploit validation, and reporting workflows."
 hermes_requires: ">=0.18.0"
 author: "Violin contributors"

--- a/plugins/violin_guard/__init__.py
+++ b/plugins/violin_guard/__init__.py
@@ -169,12 +169,10 @@ def _on_session_finalize_hook(session_id=None, eng_dir=None, **kwargs) -> None:
     we leave a continuity marker so a fresh session can re-read pending state.
     """
     if eng_dir:
-        try:
+        with contextlib.suppress(Exception):
             pending = state.has_pending_sync(str(eng_dir))
             if pending:
                 state.set_heartbeat_pending(
                     str(eng_dir),
                     "session finalized with a pending sync lock; run violin_review_batch",
                 )
-        except Exception:
-            pass

--- a/plugins/violin_guard/command.py
+++ b/plugins/violin_guard/command.py
@@ -338,7 +338,6 @@ def check_hypothesis_freshness(
                 "or 'source unavailable' are valid outcomes when truthful."
             )
             return result
-        relevant = researched
 
     # Check for stale hypotheses (no update in 48h)
     stale = 0

--- a/plugins/violin_guard/execution.py
+++ b/plugins/violin_guard/execution.py
@@ -126,12 +126,10 @@ def _terminate_pid(pid: int) -> None:
             check=False,
         )
     else:
-        try:
+        with contextlib.suppress(ProcessLookupError):
             os.killpg(pid, signal.SIGTERM)
             time.sleep(0.2)
             os.killpg(pid, signal.SIGKILL)
-        except ProcessLookupError:
-            pass
 
 
 def _terminate_process(proc: subprocess.Popen) -> None:
@@ -144,8 +142,7 @@ def _terminate_process(proc: subprocess.Popen) -> None:
         proc.wait(timeout=1)
         return
     except (OSError, subprocess.TimeoutExpired):
-        pass
-    _terminate_pid(proc.pid)
+        _terminate_pid(proc.pid)
     if proc.poll() is None:
         with contextlib.suppress(OSError):
             proc.kill()
@@ -219,13 +216,11 @@ def _monitor_background(
             status_name = "timed_out"
             _terminate_process(proc)
             break
-        try:
+        with contextlib.suppress(OSError):
             if stdout_path.stat().st_size + stderr_path.stat().st_size > MAX_OUTPUT_BYTES:
                 status_name = "output_limited"
                 _terminate_process(proc)
                 break
-        except OSError:
-            pass
         time.sleep(0.1)
     try:
         exit_code = proc.wait(timeout=5)

--- a/plugins/violin_guard/history.py
+++ b/plugins/violin_guard/history.py
@@ -68,10 +68,9 @@ def _recorded_command(line: str) -> str | None:
         try:
             expected_length = int(length_text)
         except ValueError:
-            pass
-        else:
-            if expected_length >= 0 and len(command) == expected_length:
-                return command
+            expected_length = -1
+        if expected_length >= 0 and len(command) == expected_length:
+            return command
 
     command, marker, _receipt = payload.rpartition(_RECEIPT_MARKER)
     return command if marker else payload

--- a/plugins/violin_guard/plugin.yaml
+++ b/plugins/violin_guard/plugin.yaml
@@ -1,5 +1,5 @@
 name: violin-guard
-version: "2.0.5"
+version: "2.0.6"
 description: Typed scope guards and an execute-and-record boundary with bounded synchronization windows.
 kind: standalone
 provides_tools:

--- a/plugins/violin_guard/targets.py
+++ b/plugins/violin_guard/targets.py
@@ -7,6 +7,7 @@ URL authorities, and ``ipaddress`` for IP/CIDR validation.
 
 from __future__ import annotations
 
+import contextlib
 import ipaddress
 import re
 import shlex
@@ -154,12 +155,10 @@ def normalise_target(value: str) -> str:
 
     raw = value.strip()
     raw = re.split(r"\s+\(", raw, maxsplit=1)[0].strip()
-    try:
+    with contextlib.suppress(ValueError):
         parsed = urlsplit(raw if "://" in raw else f"//{raw}")
         if parsed.hostname:
             return parsed.hostname.lower()
-    except ValueError:
-        pass
     return raw.lower()
 
 
@@ -220,12 +219,10 @@ def resolve_target(
 
     # Extract the requested field from a URL
     if "://" in target_val and field in ("ip", "host"):
-        try:
+        with contextlib.suppress(ValueError):
             parsed = urlsplit(target_val)
             if parsed.hostname:
                 return parsed.hostname
-        except Exception:
-            pass
 
     return target_val
 
@@ -291,12 +288,10 @@ def _parse_target_token(token: str) -> str | None:
     if not raw:
         return None
     unbracketed = raw[1:-1] if raw.startswith("[") and raw.endswith("]") else raw
-    try:
+    with contextlib.suppress(ValueError):
         if "/" in unbracketed:
             return str(ipaddress.ip_network(unbracketed, strict=False)).lower()
         return str(ipaddress.ip_address(unbracketed)).lower()
-    except ValueError:
-        pass
 
     try:
         parsed = urlsplit(raw if raw.startswith("//") or "://" in raw else f"//{raw}")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "violin"
-version = "2.0.5"
+version = "2.0.6"
 description = "Supervised agentic Hermes penetration-testing profile"
 requires-python = ">=3.11"
 dependencies = ["filelock>=3.13,<4"]

--- a/tests/guard/state/test_burst_and_target.py
+++ b/tests/guard/state/test_burst_and_target.py
@@ -75,6 +75,12 @@ def test_target_role_preserves_ipv6_url_hostname():
     assert resolve_target(scope, role="web", host_query=None, field="host") == "2001:db8::1"
 
 
+def test_target_role_preserves_malformed_url_for_review():
+    scope = {"targets": {"roles": {"web": "http://[broken"}}}
+
+    assert resolve_target(scope, role="web", host_query=None, field="host") == "http://[broken"
+
+
 def _run(*args):
     return subprocess.run(
         [sys.executable, str(ROOT / "scripts" / "violin_guard.py"), *args],
@@ -143,13 +149,6 @@ def test_target_requires_eng_dir():
 
 
 # --- violin_exec_burst -----------------------------------------------------
-
-_GATE_OK = {
-    "status": "ok",
-    "errors": [],
-    "warnings": [],
-    "infos": [],
-}
 
 
 def _patch_burst(monkeypatch, eng_dir):

--- a/uv.lock
+++ b/uv.lock
@@ -154,7 +154,7 @@ wheels = [
 
 [[package]]
 name = "violin"
-version = "2.0.5"
+version = "2.0.6"
 source = { virtual = "." }
 dependencies = [
     { name = "filelock" },


### PR DESCRIPTION
## What changed

- replaced pass-only exception handlers with explicit, narrowly scoped fallback paths
- removed one unused test fixture constant and one unused hypothesis assignment
- added regression coverage for malformed target URL fallback
- included the v2.0.5 history parser's new empty handler so the next scan remains clean
- bumped the patch release to `2.0.6` and updated all release metadata and the changelog

## Why

GitHub's current Code Quality scan reports five empty-except findings, one unused global, and one unused local. Silent handlers make intentional recovery behavior harder to distinguish from accidental error swallowing, while dead assignments add noise.

## Impact

Runtime behavior is preserved: missing processes remain safe to ignore, background output checks retry when files are temporarily unavailable, malformed targets remain available for scope review, and session-finalization hooks remain non-fatal. The URL fallback now catches only the expected `ValueError` instead of every exception.

## Validation

- `uv run pytest tests/guard/state/test_burst_and_target.py tests/guard/state/test_executor_and_adapters.py tests/guard/guards/test_history_staleness.py tests/guard/guards/test_scope_authorization.py -q --basetemp .pytest-v206-quality-focused` — 44 passed
- `uv run ruff check .`
- `uv run ruff format --check .`
- `git diff --check`
- `python scripts\violin_guard.py check-release`

## Tracking

Addresses all seven open GitHub Standard Code Quality findings visible before this patch.