### PR TITLE
Add skill delivery receipts

### DIFF
--- a/plugins/violin_guard/skill_receipts.py
+++ b/plugins/violin_guard/skill_receipts.py
@@ -1,0 +1,331 @@
+"""Locked, receipt-backed skill delivery state.
+
+The module is deliberately latent in v3-02: callers may prepare and bind
+deliveries, but existing execution guards do not consume the receipts until
+the command-gate migration branch.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from collections.abc import Callable
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any
+
+from . import state
+from .skill_policy import validate_skill_selection
+
+__all__ = [
+    "DeliveryReservation",
+    "HermesSkillViewAdapter",
+    "SkillViewResult",
+    "advance_context_generation",
+    "bind_task",
+    "complete_delivery",
+    "get_binding",
+    "get_delivery",
+    "prepare_delivery",
+    "prepare_review_readiness",
+]
+
+_FILE_NAME = "skills.json"
+_SCHEMA_VERSION = 1
+_MAX_DELIVERIES = 200
+
+
+def _now() -> str:
+    return datetime.now(UTC).isoformat().replace("+00:00", "Z")
+
+
+def _digest(value: str) -> str:
+    return "sha256:" + hashlib.sha256(value.encode("utf-8")).hexdigest()
+
+
+def _path(eng_dir: str | Path) -> Path:
+    return state.resolve_eng_dir(eng_dir) / "state" / _FILE_NAME
+
+
+def _empty(session_id: str = "", generation: int = 0) -> dict[str, Any]:
+    return {
+        "schema_version": _SCHEMA_VERSION,
+        "context": {"session_id": session_id, "generation": generation},
+        "deliveries": {},
+        "bindings": {},
+        "review_readiness": {},
+    }
+
+
+def _load(path: Path) -> tuple[dict[str, Any], bool]:
+    """Load valid receipt state; recover malformed/old documents fail-closed."""
+
+    if not path.exists():
+        return _empty(), False
+    try:
+        raw = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return _empty(), True
+    if not isinstance(raw, dict) or raw.get("schema_version") != _SCHEMA_VERSION:
+        return _empty(), True
+    if not isinstance(raw.get("context"), dict) or not isinstance(raw.get("deliveries"), dict):
+        return _empty(), True
+    raw.setdefault("bindings", {})
+    raw.setdefault("review_readiness", {})
+    return raw, False
+
+
+def _mutate(eng_dir: str | Path, mutation: Callable[[dict[str, Any]], Any]) -> Any:
+    path = _path(eng_dir)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with state.lock_file(path):
+        data, recovered = _load(path)
+        if recovered:
+            data["recovered_at"] = _now()
+        result = mutation(data)
+        state.atomic_json(path, data)
+        return result
+
+
+def _context(data: dict[str, Any], session_id: str) -> tuple[str, int]:
+    context = data.setdefault("context", {"session_id": "", "generation": 0})
+    recorded = str(context.get("session_id") or "")
+    if recorded and recorded != session_id:
+        # A new Hermes session is a new context, never proof of the old load.
+        context["session_id"] = session_id
+        context["generation"] = int(context.get("generation") or 0) + 1
+    elif not recorded:
+        context["session_id"] = session_id
+    return str(context["session_id"]), int(context.get("generation") or 0)
+
+
+def _delivery_key(session_id: str, generation: int, skill: str, bundle_digest: str) -> str:
+    return _digest(f"{session_id}\0{generation}\0{skill}\0{bundle_digest}")
+
+
+def _prune(data: dict[str, Any]) -> None:
+    deliveries = data["deliveries"]
+    if len(deliveries) <= _MAX_DELIVERIES:
+        return
+    bound = {str(binding.get("delivery_id") or "") for binding in data["bindings"].values()}
+    removable = sorted(
+        (entry for entry in deliveries.values() if entry.get("id") not in bound),
+        key=lambda entry: str(entry.get("updated_at") or ""),
+    )
+    for entry in removable[: max(0, len(deliveries) - _MAX_DELIVERIES)]:
+        deliveries.pop(entry["id"], None)
+
+
+@dataclass(frozen=True)
+class DeliveryReservation:
+    id: str
+    status: str
+    skill: str
+    bundle_digest: str
+    session_id: str
+    context_generation: int
+    owner: bool
+    recovered_state: bool = False
+
+
+@dataclass(frozen=True)
+class SkillViewResult:
+    ready: bool
+    content: str = ""
+    error: str = ""
+    path: str = ""
+
+
+class HermesSkillViewAdapter:
+    """Small adapter around Hermes's JSON-returning ``skill_view`` helper."""
+
+    def __init__(self, view: Callable[..., str] | None = None):
+        self._view = view
+
+    def view(self, skill: str, task_id: str | None = None) -> SkillViewResult:
+        try:
+            view = self._view
+            if view is None:
+                from tools.skills_tool import skill_view as view  # type: ignore[import-not-found]
+            raw = view(skill, task_id=task_id)
+            payload = json.loads(raw) if isinstance(raw, str) else raw
+            if not isinstance(payload, dict) or not payload.get("success"):
+                return SkillViewResult(
+                    False, error=str((payload or {}).get("error") or "skill_view failed")
+                )
+            content = str(payload.get("content") or "")
+            if not content:
+                return SkillViewResult(False, error="skill_view returned no skill content")
+            return SkillViewResult(True, content=content, path=str(payload.get("path") or ""))
+        except Exception as exc:  # Hermes availability is an external dependency.
+            return SkillViewResult(False, error=f"skill_view unavailable: {exc}")
+
+
+def prepare_delivery(
+    eng_dir: str | Path,
+    *,
+    session_id: str,
+    skill: str,
+    bundle_digest: str,
+    phase: str,
+    vulnerability_class: str | None = None,
+    candidate_source: str | None = None,
+) -> DeliveryReservation:
+    """Reserve exactly one delivery for a semantic receipt key.
+
+    Only the caller receiving ``owner=True`` may invoke Hermes and then call
+    :func:`complete_delivery`; concurrent callers see the same ``preparing``
+    receipt and never receive duplicate skill content.
+    """
+
+    if not session_id.strip() or not bundle_digest.startswith("sha256:"):
+        raise ValueError("session_id and a sha256 bundle_digest are required")
+    policy = validate_skill_selection(skill, phase, vulnerability_class, candidate_source)
+    if policy.mismatch_reasons:
+        raise ValueError("; ".join(policy.mismatch_reasons))
+
+    def reserve(data: dict[str, Any]) -> DeliveryReservation:
+        current_session, generation = _context(data, session_id.strip())
+        identifier = _delivery_key(current_session, generation, skill, bundle_digest)
+        existing = data["deliveries"].get(identifier)
+        if existing and existing.get("status") in {"preparing", "delivered"}:
+            return DeliveryReservation(
+                identifier,
+                existing["status"],
+                skill,
+                bundle_digest,
+                current_session,
+                generation,
+                False,
+            )
+        data["deliveries"][identifier] = {
+            "id": identifier,
+            "skill": skill,
+            "bundle_digest": bundle_digest,
+            "session_id": current_session,
+            "context_generation": generation,
+            "status": "preparing",
+            "created_at": _now(),
+            "updated_at": _now(),
+            "attempts": int((existing or {}).get("attempts") or 0) + 1,
+        }
+        _prune(data)
+        return DeliveryReservation(
+            identifier, "preparing", skill, bundle_digest, current_session, generation, True
+        )
+
+    return _mutate(eng_dir, reserve)
+
+
+def complete_delivery(
+    eng_dir: str | Path,
+    reservation: DeliveryReservation,
+    result: SkillViewResult,
+    *,
+    delivered_turn_id: str | None = None,
+) -> DeliveryReservation:
+    """Complete a reservation after an actual Hermes ``skill_view`` call."""
+
+    def complete(data: dict[str, Any]) -> DeliveryReservation:
+        entry = data["deliveries"].get(reservation.id)
+        if not entry or entry.get("status") != "preparing":
+            raise ValueError("delivery reservation is no longer active")
+        entry["status"] = "delivered" if result.ready else "failed"
+        entry["updated_at"] = _now()
+        entry["delivered_turn_id"] = delivered_turn_id if result.ready else None
+        entry["content_digest"] = _digest(result.content) if result.ready else None
+        entry["error"] = result.error if not result.ready else None
+        data["deliveries"][reservation.id] = entry
+        return DeliveryReservation(
+            reservation.id,
+            entry["status"],
+            reservation.skill,
+            reservation.bundle_digest,
+            reservation.session_id,
+            reservation.context_generation,
+            False,
+        )
+
+    return _mutate(eng_dir, complete)
+
+
+def get_delivery(eng_dir: str | Path, delivery_id: str) -> dict[str, Any] | None:
+    data, _ = _load(_path(eng_dir))
+    return data["deliveries"].get(delivery_id)
+
+
+def advance_context_generation(eng_dir: str | Path, session_id: str) -> int:
+    """Invalidate active bindings after Hermes context reset/compression."""
+
+    def advance(data: dict[str, Any]) -> int:
+        _context(data, session_id.strip())
+        data["context"]["generation"] = int(data["context"].get("generation") or 0) + 1
+        return data["context"]["generation"]
+
+    return _mutate(eng_dir, advance)
+
+
+def bind_task(
+    eng_dir: str | Path,
+    *,
+    task_id: str,
+    delivery_id: str,
+    hypothesis_id: str | None = None,
+    technique: str = "",
+) -> dict[str, Any]:
+    """Bind a delivered receipt to one task/hypothesis for later enforcement."""
+
+    def bind(data: dict[str, Any]) -> dict[str, Any]:
+        delivery = data["deliveries"].get(delivery_id)
+        if not delivery or delivery.get("status") != "delivered":
+            raise ValueError("a delivered skill receipt is required before binding")
+        binding = {
+            "task_id": task_id,
+            "delivery_id": delivery_id,
+            "skill": delivery["skill"],
+            "bundle_digest": delivery["bundle_digest"],
+            "session_id": delivery["session_id"],
+            "context_generation": delivery["context_generation"],
+            "hypothesis_id": hypothesis_id or "",
+            "technique": technique.strip(),
+            "bound_at": _now(),
+        }
+        data["bindings"][task_id] = binding
+        return binding
+
+    return _mutate(eng_dir, bind)
+
+
+def get_binding(eng_dir: str | Path, task_id: str) -> dict[str, Any] | None:
+    data, _ = _load(_path(eng_dir))
+    return data["bindings"].get(task_id)
+
+
+def prepare_review_readiness(
+    eng_dir: str | Path,
+    *,
+    finding_id: str,
+    evidence_digest: str,
+    delivery_id: str,
+) -> dict[str, Any]:
+    """Record a per-evidence-set review readiness receipt for later fp-check gating."""
+
+    def prepare(data: dict[str, Any]) -> dict[str, Any]:
+        delivery = data["deliveries"].get(delivery_id)
+        if (
+            not delivery
+            or delivery.get("status") != "delivered"
+            or delivery.get("skill") != "fp-check"
+        ):
+            raise ValueError("a delivered fp-check receipt is required for review readiness")
+        receipt = {
+            "finding_id": finding_id,
+            "evidence_digest": evidence_digest,
+            "delivery_id": delivery_id,
+            "prepared_at": _now(),
+        }
+        data["review_readiness"][f"{finding_id}:{evidence_digest}"] = receipt
+        return receipt
+
+    return _mutate(eng_dir, prepare)

--- a/tests/guard/state/test_skill_receipts.py
+++ b/tests/guard/state/test_skill_receipts.py
@@ -1,0 +1,147 @@
+"""Receipt-store behaviour is tested before any execution gate consumes it."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from plugins.violin_guard.skill_receipts import (
+    HermesSkillViewAdapter,
+    SkillViewResult,
+    advance_context_generation,
+    bind_task,
+    complete_delivery,
+    get_binding,
+    get_delivery,
+    prepare_delivery,
+    prepare_review_readiness,
+)
+
+
+def _reserve(eng: Path, **overrides):
+    values = {
+        "session_id": "session-a",
+        "skill": "pentest",
+        "bundle_digest": "sha256:" + "a" * 64,
+        "phase": "recon",
+    }
+    values.update(overrides)
+    return prepare_delivery(eng, **values)
+
+
+def _deliver(eng: Path, **overrides):
+    reservation = _reserve(eng, **overrides)
+    assert reservation.owner
+    return complete_delivery(
+        eng, reservation, SkillViewResult(True, content="# Skill"), delivered_turn_id="turn-1"
+    )
+
+
+def test_first_delivery_then_reuse(tmp_path: Path) -> None:
+    first = _reserve(tmp_path)
+    assert first.owner and first.status == "preparing"
+    delivered = complete_delivery(tmp_path, first, SkillViewResult(True, content="# Skill"))
+    reused = _reserve(tmp_path)
+
+    assert delivered.status == "delivered"
+    assert not reused.owner and reused.status == "delivered"
+
+
+def test_concurrent_duplicate_only_has_one_owner(tmp_path: Path) -> None:
+    first = _reserve(tmp_path)
+    duplicate = _reserve(tmp_path)
+
+    assert first.owner
+    assert not duplicate.owner
+    assert duplicate.id == first.id
+    assert duplicate.status == "preparing"
+
+
+def test_context_reset_requires_a_new_delivery(tmp_path: Path) -> None:
+    old = _deliver(tmp_path)
+    assert advance_context_generation(tmp_path, "session-a") == 1
+    new = _reserve(tmp_path)
+
+    assert new.owner
+    assert new.id != old.id
+    assert new.context_generation == 1
+
+
+def test_digest_change_requires_a_new_delivery(tmp_path: Path) -> None:
+    old = _deliver(tmp_path)
+    new = _reserve(tmp_path, bundle_digest="sha256:" + "b" * 64)
+
+    assert new.owner
+    assert new.id != old.id
+
+
+def test_failed_delivery_can_be_retried(tmp_path: Path) -> None:
+    first = _reserve(tmp_path)
+    failed = complete_delivery(tmp_path, first, SkillViewResult(False, error="missing"))
+    retry = _reserve(tmp_path)
+
+    assert failed.status == "failed"
+    assert retry.owner
+    assert get_delivery(tmp_path, retry.id)["attempts"] == 2
+
+
+def test_corrupted_state_recovers_without_trusting_old_bindings(tmp_path: Path) -> None:
+    state_path = tmp_path / "state" / "skills.json"
+    state_path.parent.mkdir()
+    state_path.write_text("{broken", encoding="utf-8")
+
+    reservation = _reserve(tmp_path)
+    data = json.loads(state_path.read_text(encoding="utf-8"))
+
+    assert reservation.owner
+    assert data["recovered_at"]
+    assert data["bindings"] == {}
+
+
+def test_binding_requires_delivered_receipt_and_carries_hypothesis(tmp_path: Path) -> None:
+    pending = _reserve(tmp_path)
+    with pytest.raises(ValueError, match="delivered"):
+        bind_task(tmp_path, task_id="PT-001", delivery_id=pending.id)
+
+    delivery = complete_delivery(tmp_path, pending, SkillViewResult(True, content="# Skill"))
+    binding = bind_task(
+        tmp_path,
+        task_id="PT-001",
+        delivery_id=delivery.id,
+        hypothesis_id="H-001",
+        technique="http probe",
+    )
+
+    assert binding["hypothesis_id"] == "H-001"
+    assert get_binding(tmp_path, "PT-001") == binding
+
+
+def test_review_readiness_is_evidence_specific(tmp_path: Path) -> None:
+    receipt = _deliver(
+        tmp_path,
+        skill="fp-check",
+        phase="retrospective",
+        bundle_digest="sha256:" + "f" * 64,
+    )
+    first = prepare_review_readiness(
+        tmp_path, finding_id="FIND-001", evidence_digest="sha256:e1", delivery_id=receipt.id
+    )
+    second = prepare_review_readiness(
+        tmp_path, finding_id="FIND-001", evidence_digest="sha256:e2", delivery_id=receipt.id
+    )
+
+    assert first["evidence_digest"] != second["evidence_digest"]
+
+
+def test_adapter_returns_structured_success_and_failure() -> None:
+    success = HermesSkillViewAdapter(
+        lambda *_args, **_kwargs: '{"success": true, "content": "body", "path": "x"}'
+    )
+    failure = HermesSkillViewAdapter(
+        lambda *_args, **_kwargs: '{"success": false, "error": "not installed"}'
+    )
+
+    assert success.view("pentest").ready
+    assert failure.view("pentest").error == "not installed"


### PR DESCRIPTION
## What changed

Adds the locked, latent `state/skills.json` receipt engine: context generations, delivery states, semantic deduplication, task/hypothesis bindings, review-readiness receipts, bounded cleanup, and a structured Hermes `skill_view` adapter.

## Why

This independently establishes proof of skill delivery before the later PTT and command-gate migrations consume it. Existing marker behavior and execution schemas remain unchanged.

## Validation

- `uv run pytest tests/guard/state/test_skill_receipts.py -q --basetemp .pytest-v3-02-receipts` (9 passed)
- `uv run pytest tests/guard -q --basetemp .pytest-v3-02-guard` (179 passed)
- `git diff --check`
- `python scripts/violin_guard.py check-release`