### PR TITLE
docs: fix repo layout playbook breakdown for v2.0.6

### DIFF
--- a/README.md
+++ b/README.md
@@ -226,13 +226,13 @@ violin/
 │   ├── smoke-test.ps1      # Windows supplemental smoke
 │   └── kali.sh             # Docker Kali helper
 └── skills/
-    ├── pentest/            # Orchestrator, workflow, shared policy, and templates
+    ├── pentest/            # Engagement orchestrator (23 playbooks, 10 refs, 11 templates)
     │   ├── SKILL.md
-    │   ├── playbooks/      # 23 operational and vulnerability-class playbooks
+    │   ├── playbooks/      # 7 operational + 16 vulnerability-class playbooks
     │   ├── references/     # 10 reference files
-    │   └── templates/      # 11 engagement, evidence, and methodology helpers
-    ├── web-attacks/        # Routed skill + 5 injection/web playbooks
-    └── access-control/     # Routed skill + 3 authentication/authorisation playbooks
+    │   └── templates/      # 11 templates (reports, evidence, methodology, contracts)
+    ├── web-attacks/        # Routed skill — 5 injection/web playbooks (SQLi, XSS, SSRF, cmdi, traversal)
+    └── access-control/     # Routed skill — 3 auth/authorisation playbooks (auth-bypass, IDOR, JWT)
 ```
 
 ---


### PR DESCRIPTION
## What

Fixes the repository layout diagram in README.md to accurately reflect v2.0.6:

- **Pentest skill**: clarify 7 operational + 16 vulnerability-class playbooks (not just "23 playbooks")
- **Web-attacks skill**: list the 5 playbooks explicitly (SQLi, XSS, SSRF, cmdi, traversal)
- **Access-control skill**: list the 3 playbooks (auth-bypass, IDOR, JWT)
- Template line: clarify what the 11 templates cover

## Why

The repo layout tree was vague — it said "23 operational and vulnerability-class playbooks" under pentest only, hiding the 8 playbooks in web-attacks and access-control that were split out in v2.0.0.

## Also included

- GitHub About description updated: "8 references" → "10 references" (via `gh repo edit`)