### PR TITLE
fix(benchmark): use correct init-engagement CLI args

### DIFF
--- a/README.md
+++ b/README.md
@@ -226,13 +226,13 @@ violin/
 │   ├── smoke-test.ps1      # Windows supplemental smoke
 │   └── kali.sh             # Docker Kali helper
 └── skills/
-    ├── pentest/            # Orchestrator, workflow, shared policy, and templates
+    ├── pentest/            # Engagement orchestrator (23 playbooks, 10 refs, 11 templates)
     │   ├── SKILL.md
-    │   ├── playbooks/      # 23 operational and vulnerability-class playbooks
+    │   ├── playbooks/      # 7 operational + 16 vulnerability-class playbooks
     │   ├── references/     # 10 reference files
-    │   └── templates/      # 11 engagement, evidence, and methodology helpers
-    ├── web-attacks/        # Routed skill + 5 injection/web playbooks
-    └── access-control/     # Routed skill + 3 authentication/authorisation playbooks
+    │   └── templates/      # 11 templates (reports, evidence, methodology, contracts)
+    ├── web-attacks/        # Routed skill — 5 injection/web playbooks (SQLi, XSS, SSRF, cmdi, traversal)
+    └── access-control/     # Routed skill — 3 auth/authorisation playbooks (auth-bypass, IDOR, JWT)
 ```
 
 ---

--- a/benchmark/targets/duck-store/anti-walkthrough.md
+++ b/benchmark/targets/duck-store/anti-walkthrough.md
@@ -1,10 +1,22 @@
-Load the pentest skill. Then create an engagement:
+Load the pentest skill. Then bootstrap the engagement:
 
 ```
 python scripts/violin_guard.py init-engagement \
-  --scope-file C:/Users/Hello/Repos/violin/benchmark/targets/duck-store/scope.yaml \
+  --host duck-store.escape.tech \
   --session-id duck-store-benchmark \
   engagements/duck-store-benchmark
+```
+
+Then replace the generated scope with our pre-baked benchmark scope:
+
+```
+cp C:/Users/Hello/Repos/violin/benchmark/targets/duck-store/scope.yaml \
+   engagements/duck-store-benchmark/scope/scope.yaml
+```
+
+Run check-bootstrap to confirm:
+```
+python scripts/violin_guard.py check-bootstrap engagements/duck-store-benchmark
 ```
 
 BENCHMARK RULES:


### PR DESCRIPTION
The anti-walkthrough prompt referenced `--scope-file` which doesn't exist. `init-engagement` takes `--host`, `--session-id`, not `--scope-file`. Fixed: run init-engagement first, then copy pre-baked scope over generated one.