### PR TITLE
fix(benchmark): match scope.yaml to validate_scope requirements

### DIFF
--- a/benchmark/targets/duck-store/scope.yaml
+++ b/benchmark/targets/duck-store/scope.yaml
@@ -1,19 +1,19 @@
 engagement:
   client: "escape.tech (benchmark)"
   tester: "Violin Benchmark"
-  date: ""
+  date: "2026-07-19"
   duration: "1 session"
 
 targets:
+  ip_addresses: ["duck-store.escape.tech"]
   domains: ["duck-store.escape.tech"]
   urls: ["https://duck-store.escape.tech"]
-  ip_addresses: []
   in_scope_urls: ["https://duck-store.escape.tech"]
 
 assessment_hosts:
   callback_hosts: []
 
-authorised_parties: ["benchmark operator"]
+authorized_parties: ["benchmark operator"]
 
 rules_of_engagement:
   allowed_actions:


### PR DESCRIPTION
Three fixes for validate_scope():
1. authorized_parties (US spelling) — validator rejects British spelling
2. targets.ip_addresses must be non-empty — filled with domain name (matches CTF template pattern)
3. engagement.date set to today — empty string triggers warning