### PR TITLE
Add semantic anti-stuck enforcement

### DIFF
--- a/plugins/violin_guard/command.py
+++ b/plugins/violin_guard/command.py
@@ -452,6 +452,13 @@ def check_command(args: CheckCommandArgs) -> CheckResult:
             result.warnings.extend(binding_result.warnings)
             result.infos.extend(binding_result.infos)
 
+    semantic_lock = state.semantic_lock(eng_dir)
+    if semantic_lock:
+        result.add_error(
+            "semantic anti-stuck lock: five evidence-poor reviews require a recorded research "
+            "attempt plus a meaningful next_technique pivot before target execution"
+        )
+
     # 5. History staleness (duplicate detection)
     pending = state.get_pending_sync(str(eng_dir)) or {}
     pending_commands = {str(item.get("command") or "") for item in pending.get("commands") or []}

--- a/plugins/violin_guard/schemas.py
+++ b/plugins/violin_guard/schemas.py
@@ -42,6 +42,14 @@ RECORD_PTT_SCHEMA = {
                 "type": "string",
                 "description": "Required for hypothesis-driven phases",
             },
+            "outcome": {
+                "type": "string",
+                "enum": ["progress", "validated", "rejected", "no_progress", "blocked"],
+            },
+            "evidence_paths": {"type": "array", "items": {"type": "string"}},
+            "next_action": {"type": "string"},
+            "next_technique": {"type": "string"},
+            "research_attempted": {"type": "boolean"},
             "title": {
                 "type": "string",
                 "description": "Required when explicitly creating a new PTT task",
@@ -147,6 +155,14 @@ REVIEW_BATCH_SCHEMA = {
                 "type": "string",
                 "description": "Required for hypothesis-driven phases",
             },
+            "outcome": {
+                "type": "string",
+                "enum": ["progress", "validated", "rejected", "no_progress", "blocked"],
+            },
+            "evidence_paths": {"type": "array", "items": {"type": "string"}},
+            "next_action": {"type": "string"},
+            "next_technique": {"type": "string"},
+            "research_attempted": {"type": "boolean"},
             "finding": {
                 "type": "object",
                 "description": "Optional structured finding derived only from this batch",

--- a/plugins/violin_guard/service.py
+++ b/plugins/violin_guard/service.py
@@ -439,6 +439,18 @@ def handle_review_batch(a, **kwargs):
                 ptt.update_task(
                     context["ptt_path"], context["task_id"], context["status"], review_note
                 )
+            semantic = state.record_semantic_review(
+                engagement,
+                task_id=context["task_id"],
+                hypothesis_id=str(a.get("hypothesis_id") or ""),
+                skill=skill or "review",
+                technique=str(a.get("technique") or "batch-review"),
+                outcome=str(a.get("outcome") or "progress"),
+                evidence_paths=[str(item) for item in (a.get("evidence_paths") or [])],
+                next_action=str(a.get("next_action") or "review evidence"),
+                next_technique=str(a.get("next_technique") or ""),
+                research_attempted=bool(a.get("research_attempted")),
+            )
             state.clear_pending_sync(engagement)
             return _json(
                 "ok",
@@ -449,6 +461,7 @@ def handle_review_batch(a, **kwargs):
                 finding=finding_result,
                 finding_path=finding_result.get("path") if finding_result else None,
                 binding_task_id=(context["task_id"] if skill else None),
+                semantic_progress=semantic,
             )
     except (OSError, ValueError) as exc:
         return _json(

--- a/plugins/violin_guard/state.py
+++ b/plugins/violin_guard/state.py
@@ -37,6 +37,7 @@ _SYNC_FILE = "sync.json"
 _HEARTBEAT_FILE = "heartbeat.json"
 _COUNTS_FILE = "counts.json"
 _SESSION_FILE = "session.json"
+_SEMANTIC_FILE = "semantic-progress.json"
 
 
 # ---------------------------------------------------------------------------
@@ -290,6 +291,62 @@ def mark_ptt_reviewed(eng_dir: str | Path, task_id: str, note: str) -> None:
         data["pending"] = pending
 
     mutate_json(path, mark)
+
+
+def record_semantic_review(
+    eng_dir: str | Path,
+    *,
+    task_id: str,
+    hypothesis_id: str,
+    skill: str,
+    technique: str,
+    outcome: str,
+    evidence_paths: list[str],
+    next_action: str,
+    next_technique: str,
+    research_attempted: bool = False,
+) -> dict[str, Any]:
+    """Track evidence-backed semantic progress and the five-review hard lock."""
+
+    path = _state_dir(eng_dir) / _SEMANTIC_FILE
+    key = "|".join((task_id, hypothesis_id, skill, technique.strip().lower()))
+    positive = outcome in {"progress", "validated", "rejected"} and bool(evidence_paths)
+
+    def record(data: dict[str, Any]) -> dict[str, Any]:
+        entries = data.setdefault("entries", {})
+        entry = entries.get(key, {"count": 0})
+        count = 0 if positive else int(entry.get("count") or 0) + 1
+        entry.update(
+            {
+                "count": count,
+                "outcome": outcome,
+                "evidence_paths": evidence_paths,
+                "next_action": next_action,
+                "next_technique": next_technique,
+                "updated_at": datetime.now(UTC).isoformat().replace("+00:00", "Z"),
+            }
+        )
+        entries[key] = entry
+        lock = data.get("lock") or {}
+        pivoted = (
+            next_technique.strip().lower()
+            and next_technique.strip().lower() != technique.strip().lower()
+        )
+        if lock and research_attempted and pivoted:
+            data.pop("lock", None)
+        elif count >= 5:
+            data["lock"] = {
+                "key": key,
+                "count": count,
+                "reason": "five semantic no-progress reviews",
+            }
+        return {"count": count, "warning": count >= 3, "locked": bool(data.get("lock"))}
+
+    return mutate_json(path, record)
+
+
+def semantic_lock(eng_dir: str | Path) -> dict[str, Any] | None:
+    return read_json(_state_dir(eng_dir) / _SEMANTIC_FILE).get("lock")
 
 
 # ---------------------------------------------------------------------------

--- a/tests/guard/state/test_semantic_anti_stuck.py
+++ b/tests/guard/state/test_semantic_anti_stuck.py
@@ -1,0 +1,49 @@
+"""Deterministic semantic no-progress counters and unlock requirements."""
+
+from __future__ import annotations
+
+from plugins.violin_guard import state
+
+
+def _review(eng, **changes):
+    values = {
+        "task_id": "PT-010",
+        "hypothesis_id": "H-001",
+        "skill": "pentest",
+        "technique": "directory-enumeration",
+        "outcome": "no_progress",
+        "evidence_paths": [],
+        "next_action": "research a different approach",
+        "next_technique": "directory-enumeration",
+        "research_attempted": False,
+    }
+    values.update(changes)
+    return state.record_semantic_review(eng, **values)
+
+
+def test_semantic_reviews_warn_then_hard_lock_and_require_research_pivot(tmp_path) -> None:
+    for _ in range(2):
+        assert not _review(tmp_path)["warning"]
+    assert _review(tmp_path)["warning"]
+    assert _review(tmp_path)["warning"]
+    locked = _review(tmp_path)
+    assert locked["locked"]
+    assert state.semantic_lock(tmp_path)
+
+    assert _review(tmp_path, research_attempted=True)["locked"]
+    assert _review(tmp_path, next_technique="parameter-discovery")["locked"]
+    unlocked = _review(tmp_path, research_attempted=True, next_technique="parameter-discovery")
+    assert not unlocked["locked"]
+    assert state.semantic_lock(tmp_path) is None
+
+
+def test_evidence_backed_progress_resets_the_semantic_counter(tmp_path) -> None:
+    _review(tmp_path)
+    _review(tmp_path)
+    result = _review(
+        tmp_path,
+        outcome="progress",
+        evidence_paths=["evidence/recon/response.txt"],
+    )
+    assert result["count"] == 0
+    assert not result["warning"]


### PR DESCRIPTION
Tracks review outcome, evidence, next action, and normalized technique by task/hypothesis/skill/technique. Evidence-backed progress resets the counter; three no-progress reviews warn and five block target execution. Unlock requires both a recorded research attempt and a changed next technique.

Validation: 188 guard tests, `git diff --check`, and `python scripts/violin_guard.py check-release`.