### PR TITLE
Remove obsolete skill marker contracts

### DIFF
--- a/plugins/violin_guard/command.py
+++ b/plugins/violin_guard/command.py
@@ -29,11 +29,9 @@ __all__ = [
     "CheckResult",
     "ScopeResult",
     "HypothesisResult",
-    "SkillLoadResult",
     "check_command",
     "validate_scope",
     "check_scope_authorization",
-    "check_skill_load",
     "check_skill_binding",
     "check_hypothesis_freshness",
 ]
@@ -52,7 +50,6 @@ class CheckCommandArgs:
     scope: str = ""
     target: str | None = None
     session_id: str | None = None
-    skill_loaded_file: str | None = None
 
 
 @dataclass
@@ -74,11 +71,6 @@ class ScopeResult(CheckResult):
 @dataclass
 class HypothesisResult(CheckResult):
     hypothesis_count: int = 0
-
-
-@dataclass
-class SkillLoadResult(CheckResult):
-    marker_path: str | None = None
 
 
 # ---------------------------------------------------------------------------
@@ -232,40 +224,9 @@ def check_local_artifact_paths(command: str) -> CheckResult:
     return result
 
 
-def check_skill_load(eng_dir: Path, session_id: str, mandatory: bool = True) -> SkillLoadResult:
-    """Verify skill-load marker exists for the session."""
-    result = SkillLoadResult()
-    marker = eng_dir / "state" / f".skill-loaded-{session_id}"
-    result.marker_path = str(marker)
-
-    if not marker.exists():
-        stale_markers = sorted((eng_dir / "state").glob(".skill-loaded-*"))
-        stale_hint = ""
-        if stale_markers:
-            names = ", ".join(candidate.name for candidate in stale_markers[:3])
-            stale_hint = (
-                f"; found marker(s) for another session: {names}. "
-                f"After loading the skill, create the canonical marker: {marker}"
-            )
-        if mandatory:
-            result.add_error(f"skill-load gate not satisfied: marker missing{stale_hint}")
-        else:
-            result.add_warning(f"skill-load marker missing (non-mandatory mode){stale_hint}")
-        return result
-
-    content = marker.read_text(encoding="utf-8").strip()
-    if "skill-loaded:" not in content:
-        result.add_warning("skill-load marker exists but format is unexpected")
-
-    result.add_info(f"skill-load marker verified: {marker}")
-    return result
-
-
-def check_skill_binding(
-    eng_dir: Path, task_id: str, session_id: str, phase: Phase
-) -> SkillLoadResult:
+def check_skill_binding(eng_dir: Path, task_id: str, session_id: str, phase: Phase) -> CheckResult:
     """Require a delivered, current-context receipt binding for target work."""
-    result = SkillLoadResult()
+    result = CheckResult()
     binding = get_binding(eng_dir, task_id)
     if not binding:
         result.add_error(f"skill receipt binding missing for active task {task_id}")

--- a/scripts/violin_guard.py
+++ b/scripts/violin_guard.py
@@ -30,7 +30,6 @@ def cmd_check_command(args: argparse.Namespace) -> int:
         scope=args.scope,
         target=args.target or None,
         session_id=args.session_id or "",
-        skill_loaded_file=args.skill_loaded_file or "",
     )
     result = command.check_command(cmd_args)
     return _print_result(result)
@@ -213,7 +212,6 @@ def cmd_exec_burst(args: argparse.Namespace) -> int:
                 "commands": [],
                 "commands_file": args.commands_file or "",
                 "session_id": args.session_id or "",
-                "skill_loaded_file": args.skill_loaded_file or "",
                 "label": args.label or "",
                 "continue_on_error": args.continue_on_error,
             }
@@ -243,7 +241,6 @@ def main() -> int:
     p.add_argument("--scope", default="", help="defaults to <eng-dir>/scope/scope.yaml")
     p.add_argument("--target", default="", help="Explicit primary target host/IP/URL")
     p.add_argument("--session-id", default="")
-    p.add_argument("--skill-loaded-file", default="")
     p.set_defaults(func=cmd_check_command)
 
     # check-bootstrap
@@ -344,7 +341,6 @@ def main() -> int:
     p.add_argument("--target", required=True, help="Explicit primary target for the batch")
     p.add_argument("--commands-file", default="")
     p.add_argument("--session-id", default="")
-    p.add_argument("--skill-loaded-file", default="")
     p.add_argument("--label", default="")
     p.add_argument("--continue-on-error", action="store_true")
     p.set_defaults(func=cmd_exec_burst)

--- a/tests/guard/docs/test_correctness_roadmap_1_1_1.py
+++ b/tests/guard/docs/test_correctness_roadmap_1_1_1.py
@@ -50,7 +50,6 @@ from plugins.violin_guard import (  # noqa: E402
     execution,
     ptt,  # noqa: E402
 )
-from plugins.violin_guard.command import check_skill_load  # noqa: E402
 
 
 def _init_e2e(tmp_path, skill_file, allowed=("recon", "vuln-research", "exploitation")):
@@ -227,7 +226,6 @@ def test_post_exploitation_requires_scope_and_skill_load(tmp_path):
             eng_dir=str(eng),
             scope=str(eng / "scope" / "scope.yaml"),
             session_id="ts",
-            skill_loaded_file=str(skill_file),
         )
     )
     assert not res.errors, f"in-scope post-exploitation must pass core gate: {res.errors}"
@@ -239,13 +237,9 @@ def test_post_exploitation_requires_scope_and_skill_load(tmp_path):
             eng_dir=str(eng),
             scope=str(eng / "scope" / "scope.yaml"),
             session_id="ts",
-            skill_loaded_file=str(skill_file),
         )
     )
     assert res_oob.errors, "post-exploitation out-of-scope must be rejected"
-
-    gate = check_skill_load(eng / "no-skill-loaded", "ts", mandatory=True)
-    assert gate.errors, "skill-load gate must BLOCK post-exploitation without marker"
 
 
 # --------------------------------------------------------------------------- #

--- a/tests/guard/integration/test_plugin_guard.py
+++ b/tests/guard/integration/test_plugin_guard.py
@@ -181,7 +181,6 @@ def test_recon_does_not_require_hypothesis(tmp_path):
             phase="recon",
             eng_dir=str(eng),
             scope=str(eng / "scope" / "scope.yaml"),
-            skill_loaded_file=str(skill_file),
             session_id="ts",
         )
     )
@@ -196,7 +195,6 @@ def test_recon_does_not_require_hypothesis(tmp_path):
             phase="vuln-research",
             eng_dir=str(eng),
             scope=str(eng / "scope" / "scope.yaml"),
-            skill_loaded_file=str(skill_file),
             session_id="ts",
         )
     )
@@ -226,7 +224,6 @@ def test_recon_does_not_require_hypothesis(tmp_path):
             phase="vuln-research",
             eng_dir=str(eng),
             scope=str(eng / "scope" / "scope.yaml"),
-            skill_loaded_file=str(skill_file),
             session_id="ts",
         )
     )
@@ -249,7 +246,6 @@ def test_recon_does_not_require_hypothesis(tmp_path):
             phase="vuln-research",
             eng_dir=str(eng),
             scope=str(eng / "scope" / "scope.yaml"),
-            skill_loaded_file=str(skill_file),
             session_id="ts",
         )
     )
@@ -462,7 +458,6 @@ def test_first_command_requires_an_active_ptt_task(tmp_path):
         phase="recon",
         eng_dir=str(eng),
         scope=str(eng / "scope" / "scope.yaml"),
-        skill_loaded_file=str(skill_file),
         session_id="ts",
     )
     first = command.check_command(args)
@@ -486,7 +481,6 @@ def test_multiple_active_ptt_tasks_block_target_execution(tmp_path):
             phase="recon",
             eng_dir=str(eng),
             scope=str(eng / "scope" / "scope.yaml"),
-            skill_loaded_file=str(skill_file),
             session_id="ts",
         )
     )
@@ -495,16 +489,8 @@ def test_multiple_active_ptt_tasks_block_target_execution(tmp_path):
     )
 
 
-def test_exec_blocked_without_skill_load(monkeypatch, tmp_path):
-    """Skill-load gate: check-command BLOCKs when the SKILL.md marker is absent,
-    and handle_exec honours that BLOCK (status 'denied')."""
-    from plugins.violin_guard.command import check_skill_load
-
-    # Real gate: missing marker file => BLOCK (error).
-    gate = check_skill_load(Path(tmp_path / "no-skill-loaded"), "test", mandatory=True)
-    assert gate.errors, "missing skill-loaded marker must BLOCK"
-
-    # handle_exec must translate a BLOCKed check-command into 'denied'.
+def test_exec_blocked_without_receipt_binding(monkeypatch, tmp_path):
+    """Target execution remains denied when its receipt binding is absent."""
     _patch(monkeypatch, _cp(1, "BLOCK: skill load gate not satisfied\n"))
     out = json.loads(
         TOOLS.handle_exec(
@@ -518,20 +504,6 @@ def test_exec_blocked_without_skill_load(monkeypatch, tmp_path):
     )
     assert out["status"] in ("denied", "error")
     assert out["status"] in ("denied", "error")
-
-
-def test_skill_load_gate_identifies_stale_session_marker(tmp_path):
-    from plugins.violin_guard.command import check_skill_load
-
-    state = tmp_path / "state"
-    state.mkdir()
-    (state / ".skill-loaded-old-session").write_text("skill-loaded: test\n", encoding="utf-8")
-
-    gate = check_skill_load(tmp_path, "current-session", mandatory=True)
-
-    assert gate.errors
-    assert ".skill-loaded-old-session" in gate.errors[0]
-    assert str(state / ".skill-loaded-current-session") in gate.errors[0]
 
 
 def test_init_engagement_creates_compliant_artifacts(tmp_path):


### PR DESCRIPTION
Removes the obsolete marker-only `check_skill_load` API, result type, CLI argument, and burst/check-command plumbing. Legacy markers remain read-only session-ID migration data and are still reported as obsolete by status.

Validation: 187 guard tests, `git diff --check`, and `python scripts/violin_guard.py check-release`.