### PR TITLE
Clean release pytest basetemps

### DIFF
--- a/plugins/violin_guard/release.py
+++ b/plugins/violin_guard/release.py
@@ -14,6 +14,7 @@ from __future__ import annotations
 import importlib.util
 import os
 import re
+import shutil
 import subprocess
 import sys
 import tempfile
@@ -181,8 +182,8 @@ def check_release() -> ReleaseCheckResult:
                 result.add_info("ruff check passed")
         except FileNotFoundError:
             result.add_warning("ruff not installed; skipped")
+        basetemp = _pytest_basetemp(repo_path)
         try:
-            basetemp = _pytest_basetemp(repo_path)
             pytest = subprocess.run(
                 [
                     python,
@@ -206,6 +207,8 @@ def check_release() -> ReleaseCheckResult:
                 result.add_info("test suite passed")
         except FileNotFoundError:
             result.add_warning("pytest not installed; skipped")
+        finally:
+            shutil.rmtree(basetemp, ignore_errors=True)
     else:
         result.add_info("heavy checks skipped (VIOLIN_CHECK_RELEASE_SKIP_HEAVY=1)")
 


### PR DESCRIPTION
Removes only the basetemp created by `check-release` after its internal pytest run, preventing temporary Hermes profile installation from copying stale protected test directories.

Validation: 187 guard tests, `check-release`, and a temporary installed Violin 3.0.0 profile smoke (deep audit; 3 local skills enabled).