### PR TITLE
Stabilize v3.0.0 workflow contracts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 3.0.0
 
+- Stabilized the core engagement workflow: domain/URL-only scopes now validate, runtime execution cannot substitute another scope file, PTT/review CLI contracts carry skill metadata, and review reuses the active delivered binding.
 - Added receipt-backed skill routing, delivery, task binding, browser enforcement, Kali auto-backend selection, proof-based finding review, and semantic anti-stuck enforcement.
 - Replaced marker-file authorization with two-turn skill preparation and receipt diagnostics; legacy markers can only infer a unique session ID during migration.
 - Allowed direct host-local `init-engagement --host` bootstrapping, persisted runtime session identity before skill delivery, and blocked shell-indirection workarounds.

--- a/plugins/violin_guard/command.py
+++ b/plugins/violin_guard/command.py
@@ -110,12 +110,29 @@ def validate_scope(scope_path: Path) -> ScopeResult:
     if not isinstance(authorisation, dict) or authorisation.get("confirmed") is not True:
         result.add_error("scope.authorisation.confirmed must be true before target execution")
 
-    # targets.ip_addresses
+    # A scope may identify targets by IP, CIDR, domain, hostname, URL, or role.
+    # Requiring an IP address made otherwise valid web/domain engagements fail
+    # before the workflow could reach authorization and execution.
     targets = data.get("targets", {})
-    if "ip_addresses" not in targets:
-        result.add_error("scope.targets.ip_addresses is required")
-    elif not isinstance(targets["ip_addresses"], list) or not targets["ip_addresses"]:
-        result.add_error("scope.targets.ip_addresses must be a non-empty list")
+    if not isinstance(targets, dict):
+        result.add_error("scope.targets must be a mapping")
+    else:
+        target_fields = ("ip_addresses", "cidrs", "domains", "hostnames", "urls", "in_scope_urls")
+        has_list_target = any(
+            isinstance(targets.get(field), list)
+            and any(str(item).strip() for item in targets.get(field, []))
+            for field in target_fields
+        )
+        roles = targets.get("roles")
+        has_role_target = isinstance(roles, dict) and any(
+            (isinstance(value, list) and any(str(item).strip() for item in value))
+            or (isinstance(value, str) and value.strip())
+            for value in roles.values()
+        )
+        if not has_list_target and not has_role_target:
+            result.add_error(
+                "scope.targets must contain at least one IP, CIDR, domain, hostname, URL, or role"
+            )
 
     assessment_hosts = data.get("assessment_hosts", {}) or {}
     if not isinstance(assessment_hosts, dict):
@@ -144,17 +161,52 @@ def validate_scope(scope_path: Path) -> ScopeResult:
     return result
 
 
-_PHASE_ACTION_TERMS = {
-    Phase.SCOPING: ("scope",),
-    Phase.RECON: ("recon", "discovery", "banner", "version", "scan", "enumerat"),
-    Phase.VULN_RESEARCH: ("vuln", "research", "cve", "exploitdb"),
-    Phase.EXPLOITATION: ("exploit", "validation", "poc"),
-    Phase.POST_EXPLOITATION: ("post-exploit", "post exploitation", "exploit", "validation"),
-    Phase.PRIVESC: ("privilege", "privesc", "exploit", "validation"),
-    Phase.FLAGS: ("flag", "capture"),
-    Phase.REPORTING: ("report",),
-    Phase.RETROSPECTIVE: ("retrospective",),
+_PHASE_ACTIONS = {
+    Phase.SCOPING: frozenset({"scope", "scoping"}),
+    Phase.RECON: frozenset(
+        {
+            "recon",
+            "discovery",
+            "host port discovery",
+            "host-port-discovery",
+            "banner grabbing",
+            "banner-grabbing",
+            "version detection",
+            "version-detection",
+            "scanning",
+            "enumeration",
+        }
+    ),
+    Phase.VULN_RESEARCH: frozenset(
+        {
+            "vulnerability research",
+            "vulnerability-research",
+            "vuln-research",
+            "research",
+            "cve-research",
+            "exploitdb",
+        }
+    ),
+    Phase.EXPLOITATION: frozenset(
+        {
+            "exploitation",
+            "exploit validation",
+            "exploit-validation",
+            "poc",
+            "poc validation",
+            "poc-validation",
+        }
+    ),
+    Phase.POST_EXPLOITATION: frozenset({"post-exploitation", "post exploitation"}),
+    Phase.PRIVESC: frozenset({"privilege escalation", "privilege-escalation", "privesc"}),
+    Phase.FLAGS: frozenset({"flags", "flag capture", "flag-capture"}),
+    Phase.REPORTING: frozenset({"report", "reporting"}),
+    Phase.RETROSPECTIVE: frozenset({"retrospective"}),
 }
+
+
+def _normalise_action(value: object) -> str:
+    return " ".join(str(value).strip().lower().replace("_", " ").replace("/", " ").split())
 
 
 def check_scope_authorization(scope: dict[str, Any] | None, phase: Phase) -> CheckResult:
@@ -163,17 +215,17 @@ def check_scope_authorization(scope: dict[str, Any] | None, phase: Phase) -> Che
     if not isinstance(scope, dict):
         return result
     roe = scope.get("rules_of_engagement") or {}
-    allowed = [str(item).lower() for item in roe.get("allowed_actions", []) or []]
-    forbidden = [str(item).lower() for item in roe.get("forbidden_actions", []) or []]
-    terms = _PHASE_ACTION_TERMS[phase]
-    if any(any(term in action for term in terms) for action in forbidden):
+    allowed = {_normalise_action(item) for item in roe.get("allowed_actions", []) or []}
+    forbidden = {_normalise_action(item) for item in roe.get("forbidden_actions", []) or []}
+    actions = _PHASE_ACTIONS[phase]
+    if forbidden & actions:
         result.add_error(
             f"phase {phase.value} conflicts with scope.rules_of_engagement.forbidden_actions"
         )
-    if not any(any(term in action for term in terms) for action in allowed):
+    if not allowed & actions:
         result.add_error(
             f"phase {phase.value} is not permitted by scope.rules_of_engagement.allowed_actions; "
-            f"add an allowed_actions entry containing one of: {', '.join(terms)}"
+            f"add an allowed_actions entry containing one of: {', '.join(sorted(actions))}"
         )
     return result
 
@@ -372,10 +424,20 @@ def check_hypothesis_freshness(
 def check_command(args: CheckCommandArgs) -> CheckResult:
     """Run all sub-guards for a target command."""
     eng_dir = state.resolve_eng_dir(args.eng_dir)
-    scope_path = Path(args.scope) if args.scope else eng_dir / "scope" / "scope.yaml"
+    canonical_scope_path = (eng_dir / "scope" / "scope.yaml").resolve()
+    requested_scope_path = (
+        Path(args.scope).expanduser().resolve() if args.scope else canonical_scope_path
+    )
+    scope_path = canonical_scope_path
     phase = normalize_phase(args.phase)
 
     result = CheckResult()
+
+    if requested_scope_path != canonical_scope_path:
+        result.add_error(
+            "runtime execution must use the engagement's canonical scope.yaml; "
+            "validate alternate scope files separately with validate-scope"
+        )
 
     # 1. Bootstrap completeness
     bootstrap_result = bootstrap.check_bootstrap(str(eng_dir), auto_repair=False)

--- a/plugins/violin_guard/handlers/adapter_handlers.py
+++ b/plugins/violin_guard/handlers/adapter_handlers.py
@@ -53,6 +53,14 @@ def _listener_scope_check(eng_dir: str, scope: str, bind_host: str, values: dict
     """Gate a local catch listener."""
     from ..targets import _callback_hosts, normalise_target, scope_hosts
 
+    canonical_scope = (_eng_path(eng_dir) / "scope" / "scope.yaml").resolve()
+    requested_scope = Path(scope).expanduser().resolve() if scope else canonical_scope
+    if requested_scope != canonical_scope:
+        return _json(
+            "blocked",
+            error="runtime adapter execution must use the engagement's canonical scope.yaml",
+        )
+
     host = (bind_host or "").strip()
     host_norm = host
     if host:
@@ -62,7 +70,7 @@ def _listener_scope_check(eng_dir: str, scope: str, bind_host: str, values: dict
             host_norm = host.split(":")[0].strip()
     if not host or host_norm in {"0.0.0.0", "::", "127.0.0.1", "::1", "localhost"}:
         return {}
-    scope_path = Path(scope) if scope else _eng_path(eng_dir) / "scope" / "scope.yaml"
+    scope_path = canonical_scope
     if not scope_path.exists():
         return {}
     try:

--- a/plugins/violin_guard/handlers/ptt_handlers.py
+++ b/plugins/violin_guard/handlers/ptt_handlers.py
@@ -14,6 +14,7 @@ from ..skill_receipts import (
     HermesSkillViewAdapter,
     bind_task,
     complete_delivery,
+    get_binding,
     prepare_delivery,
     prepare_review_readiness,
 )
@@ -508,14 +509,36 @@ def handle_review_batch(a, **kwargs):
                     finding_path=None,
                     message="nothing pending",
                 )
+            task_id = str(pending.get("ptt_task_id") or "").strip()
+            binding = get_binding(engagement, task_id) if task_id else None
+            if not binding:
+                raise ValueError(
+                    "the pending batch has no active delivered skill binding; "
+                    "rebind or prepare the active PTT task before review"
+                )
             skill = str(a.get("skill") or "").strip()
+            finding = a.get("finding")
+            expected_skill = "fp-check" if finding else str(binding.get("skill") or "")
+            if skill and skill != expected_skill:
+                raise ValueError(
+                    f"review skill {skill!r} does not match the expected binding skill {expected_skill!r}"
+                )
+            a = {
+                **a,
+                "skill": expected_skill,
+                "hypothesis_id": str(a.get("hypothesis_id") or binding.get("hypothesis_id") or ""),
+                "technique": str(a.get("technique") or binding.get("technique") or "batch-review"),
+            }
+            # A normal review certifies the already delivered execution skill.
+            # An fp-check receipt is prepared separately before a finding review;
+            # do not invoke Hermes again during the final mutation.
             if skill:
                 a, early_response = _handle_review_batch_skill_reservation(
-                    engagement, pending, a, skill
+                    engagement, pending, a, expected_skill
                 )
                 if early_response is not None:
                     return early_response
-            return _execute_batch_review(engagement, pending, a, skill)
+            return _execute_batch_review(engagement, pending, a, expected_skill)
     except (OSError, ValueError) as exc:
         return _json(
             "blocked",

--- a/plugins/violin_guard/handlers/target_handlers.py
+++ b/plugins/violin_guard/handlers/target_handlers.py
@@ -18,8 +18,14 @@ from .base import _eng_path, _json, _serialise_errors
 @_serialise_errors
 def handle_target(a, **kwargs):
     """Resolve a target value from scope.yaml."""
-    scope_path_arg = a.get("scope")
-    p = Path(scope_path_arg) if scope_path_arg else _eng_path(a["eng_dir"]) / "scope" / "scope.yaml"
+    canonical = (_eng_path(a["eng_dir"]) / "scope" / "scope.yaml").resolve()
+    scope_path_arg = str(a.get("scope") or "").strip()
+    if scope_path_arg and Path(scope_path_arg).expanduser().resolve() != canonical:
+        return _json(
+            "blocked",
+            error="runtime target resolution must use the engagement's canonical scope.yaml",
+        )
+    p = canonical
 
     if not p.exists():
         return _json("error", error=f"scope file not found: {p}")

--- a/plugins/violin_guard/schemas.py
+++ b/plugins/violin_guard/schemas.py
@@ -35,8 +35,8 @@ class RecordPttArgsModel(BaseModel):
     id: str
     status: str = ""
     note: str = ""
-    skill: str = Field("", description="Required selected Violin skill")
-    technique: str = Field("", description="Required concrete technique for this task")
+    skill: str = Field(..., description="Selected Violin skill required before task activation")
+    technique: str = Field(..., description="Concrete technique required before task activation")
     hypothesis_id: str = Field("", description="Required for hypothesis-driven phases")
     outcome: str = ""
     evidence_paths: list[str] = Field(default_factory=list)
@@ -138,7 +138,10 @@ class ReviewBatchArgsModel(BaseModel):
     id: str = Field(..., description="Active PTT task id")
     status: str
     note: str = Field(..., description="Truthful result/evidence review")
-    skill: str = Field("", description="Required selected review skill")
+    skill: str = Field(
+        "",
+        description="Review skill; defaults to the active execution binding, or fp-check for findings",
+    )
     hypothesis_id: str = Field("", description="Required for hypothesis-driven phases")
     outcome: str = ""
     evidence_paths: list[str] = Field(default_factory=list)

--- a/scripts/smoke-test.ps1
+++ b/scripts/smoke-test.ps1
@@ -1,39 +1,38 @@
-param(
-    [switch]$NoHermes
-)
-
 $ErrorActionPreference = "Stop"
-$RepoRoot = Split-Path -Parent (Split-Path -Parent $MyInvocation.MyCommand.Path)
-Set-Location $RepoRoot
 
-Write-Host "Violin smoke test (PowerShell)"
-Write-Host "Repo: $RepoRoot"
+$repoRoot = (Resolve-Path (Join-Path $PSScriptRoot "..")).Path
+$python = (Get-Command python -ErrorAction Stop).Source
+$smokeRoot = Join-Path ([System.IO.Path]::GetTempPath()) ("violin-smoke-" + [guid]::NewGuid().ToString("N"))
+$engagement = Join-Path $smokeRoot "engagement"
 
-python scripts/violin_guard.py check-release
-if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
-
-if ($NoHermes) {
-    Write-Host "Skipping Hermes install smoke because -NoHermes was supplied."
-    exit 0
+function Invoke-Guard {
+    param([string[]]$Arguments)
+    $output = & $python (Join-Path $repoRoot "scripts\violin_guard.py") @Arguments 2>&1
+    if ($LASTEXITCODE -ne 0) {
+        throw "violin_guard.py $($Arguments -join ' ') failed with exit code $LASTEXITCODE`n$($output -join "`n")"
+    }
+    return $output
 }
 
-$Hermes = Get-Command hermes -ErrorAction SilentlyContinue
-if (-not $Hermes) {
-    Write-Host "Hermes not found on PATH. Release checks passed; install smoke skipped."
-    exit 0
-}
-
-$ProfileName = "violin-smoke-$([int][double]::Parse((Get-Date -UFormat %s)))"
 try {
-    hermes profile install . --name $ProfileName -y
-    if ($LASTEXITCODE -ne 0) { throw "Hermes profile install failed." }
-    hermes profile show $ProfileName
-    if ($LASTEXITCODE -ne 0) { throw "Hermes profile show failed." }
-    hermes -p $ProfileName tools --summary
-    if ($LASTEXITCODE -ne 0) { throw "Hermes tool listing failed." }
-    hermes -p $ProfileName chat -q "Smoke test: reply with Violin profile loaded" -Q
-    if ($LASTEXITCODE -ne 0) { throw "Hermes chat smoke test failed." }
+    New-Item -ItemType Directory -Path $smokeRoot -Force | Out-Null
+    Invoke-Guard @("init-engagement", $engagement, "--host", "10.10.10.10", "--session-id", "windows-smoke") | Out-Null
+
+    $scopePath = Join-Path $engagement "scope\scope.yaml"
+    $scope = Get-Content -LiteralPath $scopePath -Raw
+    $scope = $scope -replace "confirmed: false", "confirmed: true"
+    Set-Content -LiteralPath $scopePath -Value $scope -Encoding UTF8
+    Invoke-Guard @("validate-scope", "--scope", $scopePath) | Out-Null
+
+    Invoke-Guard @(
+        "record-ptt", "--eng-dir", $engagement, "--id", "PT-001", "--status", "[~]",
+        "--note", "Windows workflow smoke", "--skill", "pentest", "--technique", "recon"
+    ) | Out-Null
+
+    Write-Output "PASS: Windows workflow smoke completed through PTT preparation."
 }
 finally {
-    hermes profile delete $ProfileName -y 2>$null
+    if (Test-Path -LiteralPath $smokeRoot) {
+        Remove-Item -LiteralPath $smokeRoot -Recurse -Force
+    }
 }

--- a/scripts/smoke-test.sh
+++ b/scripts/smoke-test.sh
@@ -164,7 +164,7 @@ fi
 mkdir -p "$SMOKE_ENG"/{scope,state,evidence}
 cp skills/pentest/templates/ptt.md "$SMOKE_ENG/state/ptt.md"
 # Update a PTT row so stale-PTT detection doesn't fire
-python3 scripts/violin_guard.py record-ptt --eng-dir "$SMOKE_ENG" --id PT-001 --status "[x]" --note "smoke bootstrap" >/dev/null 2>&1
+python3 scripts/violin_guard.py record-ptt --eng-dir "$SMOKE_ENG" --id PT-001 --status "[x]" --note "smoke bootstrap" --skill pentest --technique recon >/dev/null 2>&1
 cp skills/pentest/templates/hypothesis-board.md "$SMOKE_ENG/hypotheses.md"
 echo "# Command History — smoke" > "$SMOKE_ENG/state/history.md"
 cat > "$SMOKE_ENG/scope/scope.yaml" <<'YAML'
@@ -255,7 +255,7 @@ YAML
 
 # (a) record-ptt updates a PTT row and exits 0
 set +e
-ptt_out=$(python3 scripts/violin_guard.py record-ptt --eng-dir "$SMOKE_GUARD" --id PT-001 --status "[x]" --note "smoke test passed" 2>&1)
+ptt_out=$(python3 scripts/violin_guard.py record-ptt --eng-dir "$SMOKE_GUARD" --id PT-001 --status "[x]" --note "smoke test passed" --skill pentest --technique recon 2>&1)
 ptt_exit=$?
 set -e
 if [ "$ptt_exit" -eq 0 ] && echo "$ptt_out" | grep -q "PT-001"; then
@@ -273,7 +273,7 @@ fi
 
 # (c) record-ptt with invalid status exits 1
 set +e
-bad_ptt=$(python3 scripts/violin_guard.py record-ptt --eng-dir "$SMOKE_GUARD" --id PT-001 --status INVALID 2>&1 || true)
+bad_ptt=$(python3 scripts/violin_guard.py record-ptt --eng-dir "$SMOKE_GUARD" --id PT-001 --status INVALID --skill pentest --technique recon 2>&1 || true)
 bad_ptt_exit=$?
 set -e
 if [ "$bad_ptt_exit" -eq 1 ] || echo "$bad_ptt" | grep -qi "invalid"; then
@@ -284,7 +284,7 @@ fi
 
 # (d) record-ptt with non-existent PT id exits 1
 set +e
-bad_id=$(python3 scripts/violin_guard.py record-ptt --eng-dir "$SMOKE_GUARD" --id PT-999 --status "[~]" 2>&1)
+bad_id=$(python3 scripts/violin_guard.py record-ptt --eng-dir "$SMOKE_GUARD" --id PT-999 --status "[~]" --skill pentest --technique recon 2>&1)
 bad_id_exit=$?
 set -e
 if [ "$bad_id_exit" -eq 1 ] && echo "$bad_id" | grep -qi "not found"; then
@@ -359,7 +359,7 @@ seed_history_fixture "$SMOKE_FRESH" "nmap 10.129.45.113" RECON
 # PTT "Last updated" set to now
 sed -i "s|<YYYY-MM-DD HH:MM>|$(date '+%Y-%m-%d %H:%M')|" "$SMOKE_FRESH/state/ptt.md"
 # Mark one RECON row done so desync detection has a baseline
-python3 scripts/violin_guard.py record-ptt --eng-dir "$SMOKE_FRESH" --id PT-016 --status "[x]" --note "nmap done" >/dev/null 2>&1
+python3 scripts/violin_guard.py record-ptt --eng-dir "$SMOKE_FRESH" --id PT-016 --status "[x]" --note "nmap done" --skill pentest --technique recon >/dev/null 2>&1
 # Findings file present (non-empty) once vuln-research underway
 echo "## Findings" > "$SMOKE_FRESH/evidence/vuln-research/findings.md"
 # Skill-load marker for session 'fresh'
@@ -434,7 +434,7 @@ cat > "$SMOKE_STALEPTT/hypotheses.md" <<'MD'
 MD
 echo "# Command History" > "$SMOKE_STALEPTT/state/history.md"
 seed_history_fixture "$SMOKE_STALEPTT" "curl 10.129.45.113" EXPLOITATION
-python3 scripts/violin_guard.py record-ptt --eng-dir "$SMOKE_STALEPTT" --id PT-040 --status "[~]" --note "exploiting" >/dev/null 2>&1
+python3 scripts/violin_guard.py record-ptt --eng-dir "$SMOKE_STALEPTT" --id PT-040 --status "[~]" --note "exploiting" --skill pentest --technique exploit-validation --hypothesis-id H-001 >/dev/null 2>&1
 touch "$SMOKE_STALEPTT/state/.skill-loaded-stale"
 cat > "$SMOKE_STALEPTT/scope/scope.yaml" <<'YAML'
 engagement:
@@ -489,7 +489,7 @@ cat > "$SMOKE_STALEHYP/hypotheses.md" <<'MD'
 MD
 echo "# Command History" > "$SMOKE_STALEHYP/state/history.md"
 seed_history_fixture "$SMOKE_STALEHYP" "curl 10.129.45.113" EXPLOITATION
-python3 scripts/violin_guard.py record-ptt --eng-dir "$SMOKE_STALEHYP" --id PT-040 --status "[~]" --note "exploiting" >/dev/null 2>&1
+python3 scripts/violin_guard.py record-ptt --eng-dir "$SMOKE_STALEHYP" --id PT-040 --status "[~]" --note "exploiting" --skill pentest --technique exploit-validation --hypothesis-id H-001 >/dev/null 2>&1
 touch "$SMOKE_STALEHYP/state/.skill-loaded-sh"
 cat > "$SMOKE_STALEHYP/scope/scope.yaml" <<'YAML'
 engagement:
@@ -572,7 +572,7 @@ authorisation:
 YAML
 
 # Seed the active PTT row whose identity review-batch must preserve.
-python3 scripts/violin_guard.py record-ptt --eng-dir "$GATES_DIR" --id PT-010 --status "[~]" --note "active recon" >/dev/null 2>&1
+python3 scripts/violin_guard.py record-ptt --eng-dir "$GATES_DIR" --id PT-010 --status "[~]" --note "active recon" --skill pentest --technique recon >/dev/null 2>&1
 # Drive the canonical service handler directly.
 python3 - "$GATES_DIR" <<'PY'
 import json

--- a/scripts/violin_guard.py
+++ b/scripts/violin_guard.py
@@ -63,6 +63,10 @@ def cmd_record_ptt(args: argparse.Namespace) -> int:
                 "id": args.id,
                 "status": args.status,
                 "note": args.note or "",
+                "skill": args.skill,
+                "technique": args.technique,
+                "hypothesis_id": args.hypothesis_id,
+                "phase": args.phase,
             }
         )
     )
@@ -89,6 +93,9 @@ def cmd_review_batch(args: argparse.Namespace) -> int:
                 "id": args.id,
                 "status": args.status,
                 "note": args.note,
+                "skill": args.skill,
+                "hypothesis_id": args.hypothesis_id,
+                "technique": args.technique,
                 "finding": finding,
             }
         )
@@ -253,6 +260,10 @@ def main() -> int:
     p.add_argument("--id", required=True)
     p.add_argument("--status", required=True)
     p.add_argument("--note", default="")
+    p.add_argument("--skill", required=True)
+    p.add_argument("--technique", required=True)
+    p.add_argument("--hypothesis-id", default="")
+    p.add_argument("--phase", default="")
     p.set_defaults(func=cmd_record_ptt)
 
     p = sub.add_parser(
@@ -262,6 +273,9 @@ def main() -> int:
     p.add_argument("--id", required=True)
     p.add_argument("--status", required=True, choices=["[~]", "[x]", "[!]", "[-]"])
     p.add_argument("--note", required=True)
+    p.add_argument("--skill", default="")
+    p.add_argument("--hypothesis-id", default="")
+    p.add_argument("--technique", default="")
     p.add_argument("--finding-id", default="")
     p.add_argument("--finding-title", default="")
     p.add_argument(

--- a/skills/pentest/SKILL.md
+++ b/skills/pentest/SKILL.md
@@ -142,7 +142,7 @@ The phase workflow is mandatory for the entire session, including long, compress
    For an authorized HTB/CTF lab, `init-engagement --ctf --host <ip> --session-id <id> "$ENG_DIR"` creates a ready-to-test scope and active RECON PTT row; prepare and bind the routed skill before target activity. This exact guard CLI action is host-local and accepts a direct `--host` value through `terminal`; never hide it in a file, environment variable, or shell substitution.
 3. **Read and activate the PTT task** — `read_file path="$ENG_DIR/state/ptt.md"` — and select the next open `[ ]` task for the current phase. Before any target command, mark exactly one task `[~]`:
    ```bash
-   python $HOME/.hermes/profiles/violin/scripts/violin_guard.py record-ptt --eng-dir "$ENG_DIR" --id PT-XXX --status "[~]" --note "starting task"
+   python $HOME/.hermes/profiles/violin/scripts/violin_guard.py record-ptt --eng-dir "$ENG_DIR" --id PT-XXX --status "[~]" --note "starting task" --skill pentest --technique "<technique>" [--hypothesis-id H-001]
    ```
    With no pending batch, this is the one permitted PTT start transition. The guard hard-blocks target execution when there is no unambiguous active task or the task sits under another phase heading. The executor never changes this row or its `*Last updated*` timestamp. After each bounded batch, review the results and call `violin_review_batch` with `[~]`, `[x]`, `[!]`, or `[-]` plus a truthful result summary.
 4. **Command history is executor-owned** — `violin_exec` appends every completed target command automatically. There is no public history-writing command; inspect recent history before a new batch to avoid repeats.

--- a/tests/guard/guards/test_multiline_history_matching.py
+++ b/tests/guard/guards/test_multiline_history_matching.py
@@ -3,6 +3,12 @@ from pathlib import Path
 
 from plugins.violin_guard import bootstrap, history, state
 from plugins.violin_guard import handlers as service
+from plugins.violin_guard.skill_receipts import (
+    SkillViewResult,
+    bind_task,
+    complete_delivery,
+    prepare_delivery,
+)
 
 
 def _engagement(tmp_path: Path) -> Path:
@@ -72,6 +78,17 @@ def test_history_contains_returns_false_when_not_in_history(tmp_path: Path) -> N
 
 def test_batch_review_succeeds_for_multiline_pending_command(tmp_path: Path) -> None:
     eng = _engagement(tmp_path)
+    state.record_session_id(eng, "multiline-session")
+    reservation = prepare_delivery(
+        eng,
+        session_id="multiline-session",
+        skill="pentest",
+        bundle_digest="sha256:" + "a" * 64,
+        phase="RECON",
+    )
+    if reservation.owner:
+        reservation = complete_delivery(eng, reservation, SkillViewResult(True, content="pentest"))
+    bind_task(eng, task_id="PT-010", delivery_id=reservation.id, technique="recon")
     multiline_cmd = "cd /app\n  curl -i http://eloquia.htb/\n  wc -l index.html"
 
     # Mark pending sync with multiline command

--- a/tests/guard/state/test_workflow_contract.py
+++ b/tests/guard/state/test_workflow_contract.py
@@ -1,0 +1,78 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from plugins.violin_guard import bootstrap, command
+from plugins.violin_guard.command import check_scope_authorization, validate_scope
+from plugins.violin_guard.phases import Phase
+
+
+def _scope(tmp_path: Path, targets: str, allowed: str = "recon") -> Path:
+    path = tmp_path / "scope.yaml"
+    path.write_text(
+        f"""targets:
+  {targets}
+rules_of_engagement:
+  allowed_actions: [{allowed}]
+  forbidden_actions: []
+engagement:
+  date: 2026-08-01
+authorized_parties: [operator]
+authorisation:
+  confirmed: true
+""",
+        encoding="utf-8",
+    )
+    return path
+
+
+def test_domain_only_scope_is_valid(tmp_path: Path) -> None:
+    result = validate_scope(_scope(tmp_path, "domains: [app.example.test]"))
+    assert not any("ip_addresses" in error for error in result.errors)
+    assert not result.errors
+
+
+def test_url_only_scope_is_valid(tmp_path: Path) -> None:
+    result = validate_scope(_scope(tmp_path, "urls: [https://app.example.test/login]"))
+    assert not result.errors
+
+
+def test_exploitation_is_not_blocked_by_post_exploitation_forbidden_action() -> None:
+    result = check_scope_authorization(
+        {
+            "rules_of_engagement": {
+                "allowed_actions": ["exploitation"],
+                "forbidden_actions": ["post-exploitation"],
+            }
+        },
+        Phase.EXPLOITATION,
+    )
+    assert not result.errors
+
+
+def test_credential_stuffing_does_not_match_hydra_by_substring() -> None:
+    result = check_scope_authorization(
+        {
+            "rules_of_engagement": {
+                "allowed_actions": ["recon"],
+                "forbidden_actions": ["credential-stuffing"],
+            }
+        },
+        Phase.RECON,
+    )
+    assert not any("forbidden" in error for error in result.errors)
+
+
+def test_runtime_command_rejects_scope_substitution(tmp_path: Path) -> None:
+    engagement = tmp_path / "engagement"
+    assert bootstrap.init_engagement(engagement, host="10.10.10.10") == 0
+    result = command.check_command(
+        command.CheckCommandArgs(
+            command="echo local",
+            phase="recon",
+            eng_dir=str(engagement),
+            scope=str(tmp_path / "other-scope.yaml"),
+            target="10.10.10.10",
+        )
+    )
+    assert any("canonical scope.yaml" in error for error in result.errors)


### PR DESCRIPTION
## What changed

- Accept domain-only, hostname, CIDR, URL, and role-based scopes.
- Reject runtime scope substitution and require the canonical engagement scope.
- Replace substring ROE phase matching with normalized exact action matching.
- Align CLI PTT arguments with the runtime contract and update smoke coverage.
- Require batch review to use the active delivered skill binding.
- Add a Windows workflow smoke script and regression coverage.

## Why

The v3 workflow could reject valid web engagements, permit a caller-supplied scope path, misclassify ROE actions, and allow review requests without a delivered execution binding.

## Validation

- 258 guard tests passed.
- Ruff check and format check passed.
- git diff --check passed.
- violin_guard.py check-release passed.

Closes #54