### PR TITLE
fix: bump distribution version to 3.0.1

### DIFF
--- a/distribution.yaml
+++ b/distribution.yaml
@@ -1,5 +1,5 @@
 name: violin
-version: 3.0.0
+version: 3.0.1
 description: A supervised agentic Hermes penetration testing profile for authorised
   Kali/Parrot-based security assessment, reconnaissance, exploit validation, and reporting
   workflows.


### PR DESCRIPTION
The v3.0.1 release was tagged at d89fc64 but distribution.yaml still declared version: 3.0.0, so `hermes profile update violin` pulled the 3.0.1 code yet reported/installed v3.0.0.

Bump the manifest version field to 3.0.1 so Hermes reports the correct version.