### PR TITLE
fix: make out-of-scope hostname remediation actionable

### DIFF
--- a/plugins/violin_guard/core/targets.py
+++ b/plugins/violin_guard/core/targets.py
@@ -31,6 +31,13 @@ _PATH_VALUE_FLAGS = {
     "--output",
     "--output-dir",
 }
+_TARGET_VALUE_FLAGS = {
+    "--resolve": "resolve",
+    "-H": "header",
+    "--header": "header",
+    "--vhost": "hostname",
+    "--virtual-host": "hostname",
+}
 _REDIRECTION_OPERATORS = {">", ">>", "2>", "2>>", "&>"}
 _DEV_NETWORK_PREFIXES = ("/dev/tcp/", "/dev/udp/")
 _COMMON_FILE_SUFFIXES = {
@@ -85,8 +92,27 @@ class TargetCheckResult:
     warnings: list[str] = field(default_factory=list)
 
 
+def _unknown_hostname_diagnostic(
+    hostname: str,
+    scope_path: Path,
+    *,
+    subject: str,
+) -> str:
+    return (
+        f"{subject} {hostname} is not present in scope.yaml; "
+        f"scope file used for validation: {scope_path}; "
+        "relevant keys: targets.hostnames and targets.in_scope_urls. "
+        "The operator must confirm authorization before editing scope.yaml; "
+        "Violin never edits scope.yaml automatically. "
+        "After an authorized scope update, validate it with: "
+        "uv run python scripts/violin_guard.py validate-scope "
+        f'--scope "{scope_path}"'
+    )
+
+
 @dataclass(frozen=True)
 class _TargetPolicy:
+    scope_path: Path
     allowed: set[str]
     excluded: set[str]
     allowed_ip_set: netaddr.IPSet
@@ -168,7 +194,11 @@ class _TargetPolicy:
             )
         else:
             result.warnings.append(
-                f"primary target {candidate} is not present in scope.yaml targets; verify authorization"
+                _unknown_hostname_diagnostic(
+                    candidate,
+                    self.scope_path,
+                    subject="primary target",
+                )
             )
 
     def check_secondary(self, candidate: str, result: TargetCheckResult) -> None:
@@ -180,7 +210,7 @@ class _TargetPolicy:
             result.errors.append(f"out-of-scope target {candidate} (not present in scope.yaml)")
         else:
             result.warnings.append(
-                f"host {candidate} is not present in scope.yaml; verify authorization"
+                _unknown_hostname_diagnostic(candidate, self.scope_path, subject="host")
             )
 
 
@@ -189,7 +219,12 @@ def extract_target_candidates(command: str) -> list[str]:
     candidates: list[str] = []
     skip_path_value = False
     skip_next_token = False
+    pending_target_value: str | None = None
     for token in _command_tokens(command):
+        if pending_target_value is not None:
+            candidates.extend(_parse_target_value(pending_target_value, token))
+            pending_target_value = None
+            continue
         if skip_path_value:
             skip_path_value = False
             continue
@@ -203,6 +238,14 @@ def extract_target_candidates(command: str) -> list[str]:
             if token == "-m":
                 skip_next_token = True
             continue
+        target_argument = _target_value_argument(token)
+        if target_argument is not None:
+            target_kind, target_value = target_argument
+            if target_value is None:
+                pending_target_value = target_kind
+            else:
+                candidates.extend(_parse_target_value(target_kind, target_value))
+            continue
         if token in _REDIRECTION_OPERATORS or any(
             token.startswith(f"{flag}=") for flag in _PATH_VALUE_FLAGS
         ):
@@ -210,19 +253,81 @@ def extract_target_candidates(command: str) -> list[str]:
 
         if token.rstrip(";, ").endswith("()"):
             continue
-        candidate = token.strip("'\"(),;")
-        if candidate.lower() in _NON_TARGET_DOTTED_TOKENS:
-            continue
-        if _looks_like_local_path(candidate) and not (
-            candidate.startswith(_DEV_NETWORK_PREFIXES)
-            or candidate.startswith("//")
-            or "://" in candidate
-        ):
-            continue
-        parsed = _parse_target_token(candidate)
+        parsed = _parse_command_target_token(token)
         if parsed:
             candidates.append(parsed)
     return list(dict.fromkeys(candidates))
+
+
+def _target_value_argument(token: str) -> tuple[str, str | None] | None:
+    for flag, target_kind in _TARGET_VALUE_FLAGS.items():
+        if token == flag:
+            return target_kind, None
+        prefix = f"{flag}="
+        if token.startswith(prefix):
+            return target_kind, token.removeprefix(prefix)
+    if token.startswith("-H") and len(token) > 2:
+        return "header", token[2:].removeprefix("=")
+    return None
+
+
+def _parse_target_value(target_kind: str, value: str) -> list[str]:
+    if target_kind == "resolve":
+        return _parse_curl_resolve_targets(value)
+    if target_kind == "header":
+        match = re.match(r"(?i)^\s*host\s*:\s*(\S+)", value)
+        candidate = (
+            _parse_target_token(match.group(1)) if match else _parse_command_target_token(value)
+        )
+        return [candidate] if candidate else []
+    candidate = _parse_target_token(value)
+    return [candidate] if candidate else []
+
+
+def _parse_curl_resolve_targets(value: str) -> list[str]:
+    raw_value = value.strip()
+    if raw_value.startswith("+"):
+        raw_value = raw_value[1:]
+    elif raw_value.startswith("-"):
+        return []
+
+    if raw_value.startswith("["):
+        closing_bracket = raw_value.find("]")
+        if closing_bracket < 0 or not raw_value[closing_bracket + 1 :].startswith(":"):
+            return []
+        hostname = raw_value[1:closing_bracket]
+        remainder = raw_value[closing_bracket + 2 :]
+    else:
+        hostname, separator, remainder = raw_value.partition(":")
+        if not separator:
+            return []
+
+    port, separator, addresses = remainder.partition(":")
+    if not port or not separator:
+        return []
+
+    candidates: list[str] = []
+    hostname_candidate = _parse_target_token(hostname)
+    if hostname_candidate:
+        candidates.append(hostname_candidate)
+    for address in addresses.split(","):
+        address_candidate = _parse_target_token(address.strip())
+        if address_candidate:
+            candidates.append(address_candidate)
+    return candidates
+
+
+def _parse_command_target_token(token: str) -> str | None:
+    candidate = token.strip("'\"(),;")
+    if not candidate or candidate.lower() in _NON_TARGET_DOTTED_TOKENS:
+        return None
+    if _looks_like_local_path(candidate) and not (
+        candidate.startswith(_DEV_NETWORK_PREFIXES)
+        or candidate.startswith("//")
+        or "://" in candidate
+    ):
+        return None
+    return _parse_target_token(candidate)
 
 
 def normalize_target(value: str) -> str:
@@ -240,6 +345,8 @@ def resolve_target(
     role: str | None,
     host_query: str | None,
     field: str = "ip",
+    *,
+    scope_path: Path | None = None,
 ) -> str | None:
     """Resolve a single target value from scope data."""
     targets_sec = scope_data.get("targets", {}) or {}
@@ -275,7 +382,16 @@ def resolve_target(
             raise ValueError(f"target role {role!r} is ambiguous; expected exactly one value")
         target_val = unique[0]
     elif host_query:
-        if normalize_target(host_query) not in scope_hosts(scope_data):
+        normalized_host = normalize_target(host_query)
+        if normalized_host not in scope_hosts(scope_data):
+            if scope_path is not None and not _is_ip_network(normalized_host):
+                raise ValueError(
+                    _unknown_hostname_diagnostic(
+                        normalized_host,
+                        scope_path.expanduser().resolve(),
+                        subject="target host",
+                    )
+                )
             raise ValueError(f"target host {host_query!r} is not present in scope.yaml")
         target_val = host_query
     else:
@@ -332,12 +448,14 @@ def check_scope_targets(
 ) -> TargetCheckResult:
     """Block excluded or out-of-scope IP/CIDR targets in ``command``."""
     result = TargetCheckResult()
-    scope = _read_scope(scope_path)
+    canonical_scope_path = scope_path.expanduser().resolve()
+    scope = _read_scope(canonical_scope_path)
     if scope is None:
         return result
 
     exclusions = scope.get("exclusions", {}) or {}
     policy = _TargetPolicy(
+        scope_path=canonical_scope_path,
         allowed=scope_hosts(scope, "targets"),
         excluded=scope_hosts(scope, "exclusions"),
         allowed_ip_set=_scope_ip_set(scope, "targets"),

--- a/plugins/violin_guard/handlers/target_handlers.py
+++ b/plugins/violin_guard/handlers/target_handlers.py
@@ -41,6 +41,7 @@ def handle_target(args, **kwargs):
         role=args.get("role"),
         host_query=args.get("host"),
         field=args.get("field") or "ip",
+        scope_path=p,
     )
     if value is None:
         return _json("error", error="no targets in scope")

--- a/skills/pentest/playbooks/scoping.md
+++ b/skills/pentest/playbooks/scoping.md
@@ -228,9 +228,16 @@ vector that falls **outside** the current scope file:
    > _I discovered {target / endpoint / vector} that is not covered by the
    > current scope. Should this be added to scope or explicitly excluded?_
 3. **Update the scope file** (`$ENG_DIR/scope/scope.yaml`) based on the client's answer:
-   - Add to `targets` if included.
+   - For an authorized hostname, add the hostname to `targets.hostnames` or its
+     URL to `targets.in_scope_urls`, as appropriate.
    - Add to `exclusions` if excluded.
-4. **Do not test** the new target until the scope file has been updated **and**
+   - Violin never edits `scope.yaml` automatically; the operator must confirm
+     authorization before making this manual change.
+4. **Validate** the updated canonical scope file:
+   ```bash
+   uv run python scripts/violin_guard.py validate-scope --scope "<canonical-scope-path>"
+   ```
+5. **Do not test** the new target until the scope file has been updated **and**
    re-approved (see Re-scoping below).
 
 ---

--- a/tests/guard/gates/test_scope_authorization.py
+++ b/tests/guard/gates/test_scope_authorization.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 
 from pathlib import Path
 
+import pytest
+
 from plugins.violin_guard.core.targets import (
     check_scope_targets,
     extract_target_candidates,
@@ -101,6 +103,107 @@ def test_explicit_target_keeps_unknown_bare_hostnames_reviewable(
 
     blocked = check_scope_targets(scope, "nmap 10.10.10.99", primary_target="10.10.10.10")
     assert blocked.errors
+
+
+@pytest.mark.parametrize(
+    "command",
+    [
+        "curl https://outside.example/status",
+        "curl --resolve outside.example:443:10.10.10.10 https://10.10.10.10/status",
+        "curl -H 'Host: outside.example' http://10.10.10.10/status",
+        "scanner --vhost outside.example http://10.10.10.10/status",
+    ],
+)
+def test_unknown_hostname_sources_receive_actionable_diagnostics(
+    tmp_path: Path,
+    command: str,
+) -> None:
+    scope = tmp_path / "scope.yaml"
+    _write_scope(scope)
+
+    result = check_scope_targets(scope, command)
+
+    assert not result.errors
+    diagnostic = next(warning for warning in result.warnings if "outside.example" in warning)
+    canonical_scope = scope.resolve()
+    assert str(canonical_scope) in diagnostic
+    assert "targets.hostnames" in diagnostic
+    assert "targets.in_scope_urls" in diagnostic
+    assert (
+        f'uv run python scripts/violin_guard.py validate-scope --scope "{canonical_scope}"'
+    ) in diagnostic
+    assert "confirm authorization before editing scope.yaml" in diagnostic.lower()
+    assert "never edits scope.yaml automatically" in diagnostic
+
+
+def test_scoped_and_wildcard_hostnames_do_not_warn(tmp_path: Path) -> None:
+    scope = tmp_path / "scope.yaml"
+    scope.write_text(
+        """targets:
+  ip_addresses: [192.0.2.20]
+  hostnames: [scoped.example, '*.wild.example']
+  in_scope_urls: [https://url-scoped.example/app]
+exclusions:
+  hostnames: [excluded.example]
+""",
+        encoding="utf-8",
+    )
+
+    for command in (
+        "curl https://scoped.example/status",
+        "curl https://url-scoped.example/status",
+        "curl https://api.wild.example/status",
+        "curl --resolve scoped.example:443:192.0.2.20 https://scoped.example/status",
+        "curl -H 'Host: scoped.example' http://192.0.2.20/status",
+    ):
+        result = check_scope_targets(scope, command)
+        assert not result.errors, command
+        assert not result.warnings, command
+
+    wildcard_apex = check_scope_targets(scope, "curl https://wild.example/status")
+    assert any("wild.example" in warning for warning in wildcard_apex.warnings)
+
+
+def test_excluded_hostname_and_unauthorized_ip_remain_hard_blocks(tmp_path: Path) -> None:
+    scope = tmp_path / "scope.yaml"
+    _write_scope(scope)
+
+    excluded = check_scope_targets(scope, "curl https://excluded.example/status")
+    unauthorized_ip = check_scope_targets(scope, "curl http://10.10.10.98/status")
+    unauthorized_resolve_ip = check_scope_targets(
+        scope,
+        "curl --resolve allowed.example:443:10.10.10.98 https://allowed.example/status",
+    )
+
+    assert any("excluded target excluded.example" in error for error in excluded.errors)
+    assert any("out-of-scope target 10.10.10.98" in error for error in unauthorized_ip.errors)
+    assert any(
+        "out-of-scope target 10.10.10.98" in error for error in unauthorized_resolve_ip.errors
+    )
+
+
+@pytest.mark.parametrize(
+    "header_argument",
+    [
+        "-H 'Referer: https://outside.example/source'",
+        "-H @headers.txt",
+        "--header @headers.txt",
+    ],
+)
+def test_non_host_header_values_remain_non_targets(
+    tmp_path: Path,
+    header_argument: str,
+) -> None:
+    scope = tmp_path / "scope.yaml"
+    _write_scope(scope)
+
+    result = check_scope_targets(
+        scope,
+        f"curl {header_argument} http://10.10.10.10/status",
+    )
+
+    assert not result.errors
+    assert not result.warnings
 
 
 def test_legacy_descriptive_target_normalizes_to_host() -> None:

--- a/tests/guard/handlers/test_burst_and_target.py
+++ b/tests/guard/handlers/test_burst_and_target.py
@@ -165,10 +165,28 @@ def test_target_host_ip(eng):
     assert r.stdout.strip() == "10.10.10.10"
 
 
-def test_target_rejects_unknown_host(eng):
+def test_target_rejects_unauthorized_ip(eng):
     r = _run("target", "--eng-dir", str(eng), "--host", "10.99.99.99")
     assert r.returncode == 1
     assert "not present in scope.yaml" in r.stdout
+    assert "targets.hostnames" not in r.stdout
+
+
+def test_target_rejects_unknown_hostname_with_actionable_diagnostic(eng):
+    r = _run("target", "--eng-dir", str(eng), "--host", "outside.example")
+
+    assert r.returncode == 1
+    canonical_scope = (eng / "scope" / "scope.yaml").resolve()
+    assert "outside.example" in r.stdout
+    assert str(canonical_scope) in r.stdout
+    assert "targets.hostnames" in r.stdout
+    assert "targets.in_scope_urls" in r.stdout
+    assert (
+        f'uv run python scripts/violin_guard.py validate-scope --scope "{canonical_scope}"'
+        in r.stdout
+    )
+    assert "confirm authorization before editing scope.yaml" in r.stdout.lower()
+    assert "never edits scope.yaml automatically" in r.stdout
 
 
 def test_target_requires_eng_dir():

--- a/tests/guard/handlers/test_workflow_contract.py
+++ b/tests/guard/handlers/test_workflow_contract.py
@@ -103,6 +103,25 @@ def test_runtime_command_rejects_scope_substitution(tmp_path: Path) -> None:
     assert any("canonical scope.yaml" in error for error in result.errors)
 
 
+def test_command_scope_diagnostic_uses_canonical_path_without_mutation(tmp_path: Path) -> None:
+    engagement = tmp_path / "engagement"
+    assert bootstrap.init_engagement(engagement, host="10.10.10.10") == 0
+    scope_path = engagement / "scope" / "scope.yaml"
+    original_scope = scope_path.read_bytes()
+
+    result = command.check_command(
+        command.CheckCommandArgs(
+            command="curl https://outside.example/status",
+            phase="recon",
+            eng_dir=str(engagement),
+            target="10.10.10.10",
+        )
+    )
+
+    assert any(str(scope_path.resolve()) in warning for warning in result.warnings)
+    assert scope_path.read_bytes() == original_scope
+
+
 def test_multi_task_ptt_update_validates_before_atomic_replace(tmp_path: Path) -> None:
     path = tmp_path / "ptt.md"
     path.write_text(


### PR DESCRIPTION
## Summary

- Centralizes actionable unknown-hostname diagnostics with the exact hostname, canonical scope path, relevant scope keys, validation command, and authorization warning.
- Recognizes hostnames supplied through curl --resolve, Host headers, and explicit vhost arguments while continuing to validate mapped IP addresses fail-closed.
- Applies the same remediation to violin_target hostname rejections and documents the manual re-scoping workflow.

## Tests

- Focused regressions: 28 passed in 5.88s.
- Full suite: 490 passed in 65.20s.
- uv run ruff check .: passed.
- uv run ruff format --check .: 106 files already formatted.
- uv run python scripts/violin_guard.py check-release: passed, including its internal Ruff and pytest gates.
- git diff --check: passed.

The checks ran in the official Python 3.11 uv Docker image because Python and uv are not installed on the host.

## Safety

- Command validation only reads scope.yaml; the regression suite verifies its bytes are unchanged.
- Unauthorized IP and CIDR targets remain hard failures, including addresses supplied through curl --resolve.
- Exclusions still take precedence, and callback, research, secondary-only, wildcard, scoped hostname/URL, and payload URL behavior remains covered and unchanged.
- Violin never edits scope.yaml automatically; operators must confirm authorization before manual re-scoping.

Closes #9