### PR TITLE
fix: persist bounded execute_code result bodies

### DIFF
--- a/plugins/violin_guard/gates/code_execution_audit.py
+++ b/plugins/violin_guard/gates/code_execution_audit.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 import ast
 import hashlib
 import json
+import math
 import re
 import uuid
 from datetime import UTC, datetime
@@ -19,11 +20,62 @@ from typing import Any
 from ..core import history, state
 from ..core.ptt import find_active_task, parse_ptt
 from ..core.targets import extract_target_candidates, normalize_target
-from ..engine.execution import _commit_guard_state
+from ..engine.execution import PREVIEW_BYTES, _commit_guard_state
 from . import command
 
 _HEADER = re.compile(r"^\s*#\s*violin:\s*(\{.*\})\s*$")
 _REQUIRED_FIELDS = frozenset({"eng_dir", "phase", "target", "session_id"})
+
+# Match the executor's 32 KiB preview budget so result manifests remain useful
+# without becoming an unbounded second copy of tool output.
+MAX_STORED_RESULT_BYTES = PREVIEW_BYTES
+_REDACTED = "[REDACTED]"
+_REDACTED_JWT = "[REDACTED_JWT]"
+_REDACTED_PRIVATE_KEY = "[REDACTED_PRIVATE_KEY]"
+_REDACTED_TOKEN = "[REDACTED_TOKEN]"
+_SENSITIVE_RESULT_KEYS = frozenset(
+    {
+        "password",
+        "passwd",
+        "secret",
+        "token",
+        "access_token",
+        "refresh_token",
+        "api_key",
+        "apikey",
+        "authorization",
+        "cookie",
+        "private_key",
+        "set_cookie",
+    }
+)
+_PRIVATE_KEY_RE = re.compile(
+    r"-----BEGIN (?P<label>(?:[A-Z0-9]+ )*PRIVATE KEY(?: BLOCK)?)-----.*?"
+    r"(?:-----END (?P=label)-----|\Z)",
+    re.IGNORECASE | re.DOTALL,
+)
+_AUTHORIZATION_RE = re.compile(
+    r"(?i)([\"']?\bauthorization\b[\"']?\s*[:=]\s*)"
+    r"(?:\"(?:\\.|[^\"\\])*\"|'(?:\\.|[^'\\])*'|[^\r\n,;}]+)"
+)
+_COOKIE_RE = re.compile(
+    r"(?im)([\"']?\b(?:set[-_]?cookie|cookie)\b[\"']?\s*[:=]\s*)"
+    r"(?:\"(?:\\.|[^\"\\])*\"|'(?:\\.|[^'\\])*'|[^\r\n,}]+)"
+)
+_SECRET_ASSIGNMENT_RE = re.compile(
+    r"(?i)([\"']?\b(?:password|passwd|secret|token|access[_-]?token|refresh[_-]?token|"
+    r"api[_-]?key|apikey|private[_-]?key)\b[\"']?\s*[:=]\s*)"
+    r"(?:\"(?:\\.|[^\"\\])*\"|'(?:\\.|[^'\\])*'|[^\s,;}\]]+)"
+)
+_BEARER_TOKEN_RE = re.compile(r"(?i)\bbearer[ \t]+[A-Za-z0-9._~+/=-]{8,}")
+_JWT_RE = re.compile(
+    r"(?<![A-Za-z0-9_-])eyJ[A-Za-z0-9_-]{5,}\.[A-Za-z0-9_-]{5,}\."
+    r"[A-Za-z0-9_-]{5,}(?![A-Za-z0-9_-])"
+)
+_PROVIDER_TOKEN_RE = re.compile(
+    r"(?<![A-Za-z0-9_-])(?:sk-[A-Za-z0-9_-]{16,}|gh[pousr]_[A-Za-z0-9]{20,}|"
+    r"xox[baprs]-[A-Za-z0-9-]{10,})(?![A-Za-z0-9_-])"
+)
 
 _LOCAL_PATH_EXTENSIONS = frozenset(
     {
@@ -338,79 +390,172 @@ def record_completion(
     eng_dir = state.resolve_eng_dir(metadata["eng_dir"])
     digest = source_digest(source)
     receipt_file = Path(receipt_path)
-    receipt = state.read_json(receipt_file)
-    if receipt.get("source_digest") != digest:
-        raise ValueError("execute_code completion does not match its intent receipt")
+    with state.lock_file(receipt_file):
+        receipt = state.read_json(receipt_file)
+        if receipt.get("source_digest") != digest:
+            raise ValueError("execute_code completion does not match its intent receipt")
+        if receipt.get("status") != "starting":
+            raise ValueError(
+                f"execute_code intent receipt is already finalized as {receipt.get('status')}"
+            )
 
-    summary = _result_summary(result, duration_ms)
-    # Command identity is created before dispatch and is also stored in the
-    # pending sync batch.  Keep it byte-for-byte stable so review/rebind can
-    # reconcile the completed execution against that batch.  Outcome metadata
-    # belongs in the receipt and dedicated history fields, not in command=.
-    command_text = str(receipt.get("command") or "").strip()
-    if not command_text:
-        raise ValueError("execute_code intent receipt has no command identity")
-    completed_receipt = {
-        **receipt,
-        "status": "completed" if summary["status"] == "ok" else "completed_with_error",
-        "completed_at": datetime.now(UTC).isoformat().replace("+00:00", "Z"),
-        "duration_ms": summary["duration_ms"],
-        "exit_code": summary["exit_code"],
-    }
-    if not history.history_contains(eng_dir, command_text):
-        history.append_history(
-            eng_dir,
-            command_text,
-            metadata["phase"],
-            summary["exit_code"],
-            receipt_file.relative_to(eng_dir).as_posix(),
-            status=str(completed_receipt["status"]),
-        )
-    state.atomic_json(receipt_file, completed_receipt)
+        # Command identity is created before dispatch and is also stored in the
+        # pending sync batch.  Keep it byte-for-byte stable so review/rebind can
+        # reconcile the completed execution against that batch.  Outcome metadata
+        # belongs in the receipt and dedicated history fields, not in command=.
+        command_text = str(receipt.get("command") or "").strip()
+        if not command_text:
+            raise ValueError("execute_code intent receipt has no command identity")
+        summary = _result_summary(result, duration_ms)
+        completed_receipt = {
+            **receipt,
+            "status": "completed" if summary["status"] == "ok" else "completed_with_error",
+            "completed_at": datetime.now(UTC).isoformat().replace("+00:00", "Z"),
+            "duration_ms": summary["duration_ms"],
+            "exit_code": summary["exit_code"],
+            "result": summary["result"],
+        }
+        if not history.history_contains(eng_dir, command_text):
+            history.append_history(
+                eng_dir,
+                command_text,
+                metadata["phase"],
+                summary["exit_code"],
+                receipt_file.relative_to(eng_dir).as_posix(),
+                status=str(completed_receipt["status"]),
+            )
+        state.atomic_json(receipt_file, completed_receipt)
     return receipt_file
 
 
 def abandon_execution(receipt_path: str | Path, reason: str) -> None:
     """Close a prepared intent that cannot receive a post-tool completion."""
     receipt_file = Path(receipt_path)
-    receipt = state.read_json(receipt_file)
-    if receipt.get("status") != "starting":
-        return
-    eng_dir = receipt_file.resolve().parents[2]
-    command_text = str(receipt.get("command") or "").strip()
-    abandoned = {
-        **receipt,
-        "status": "abandoned",
-        "completed_at": datetime.now(UTC).isoformat().replace("+00:00", "Z"),
-        "exit_code": -1,
-        "error": reason,
-    }
-    if command_text and not history.history_contains(eng_dir, command_text):
-        history.append_history(
-            eng_dir,
-            command_text,
-            str(receipt.get("phase") or "RECON"),
-            -1,
-            receipt_file.relative_to(eng_dir).as_posix(),
-            status="abandoned",
-        )
-    state.atomic_json(receipt_file, abandoned)
+    with state.lock_file(receipt_file):
+        receipt = state.read_json(receipt_file)
+        if receipt.get("status") != "starting":
+            return
+        eng_dir = receipt_file.resolve().parents[2]
+        command_text = str(receipt.get("command") or "").strip()
+        abandoned = {
+            **receipt,
+            "status": "abandoned",
+            "completed_at": datetime.now(UTC).isoformat().replace("+00:00", "Z"),
+            "exit_code": -1,
+            "error": reason,
+        }
+        if command_text and not history.history_contains(eng_dir, command_text):
+            history.append_history(
+                eng_dir,
+                command_text,
+                str(receipt.get("phase") or "RECON"),
+                -1,
+                receipt_file.relative_to(eng_dir).as_posix(),
+                status="abandoned",
+            )
+        state.atomic_json(receipt_file, abandoned)
 
 
-def _result_summary(result: object, duration_ms: object) -> dict[str, int | str]:
-    try:
-        parsed: Any = json.loads(result) if isinstance(result, str) else result
-    except json.JSONDecodeError:
-        parsed = {"error": "non-JSON tool result"}
+def _normalized_result_key(key: object) -> str:
+    return re.sub(r"[-\s]+", "_", str(key).strip().casefold())
+
+
+def _redact_result_text(value: str) -> str:
+    redacted = _PRIVATE_KEY_RE.sub(_REDACTED_PRIVATE_KEY, value)
+    redacted = _COOKIE_RE.sub(lambda match: f"{match.group(1)}{_REDACTED}", redacted)
+    redacted = _AUTHORIZATION_RE.sub(lambda match: f"{match.group(1)}{_REDACTED}", redacted)
+    redacted = _SECRET_ASSIGNMENT_RE.sub(lambda match: f"{match.group(1)}{_REDACTED}", redacted)
+    redacted = _BEARER_TOKEN_RE.sub(f"Bearer {_REDACTED_TOKEN}", redacted)
+    redacted = _JWT_RE.sub(_REDACTED_JWT, redacted)
+    return _PROVIDER_TOKEN_RE.sub(_REDACTED_TOKEN, redacted)
+
+
+def _normalize_result_value(value: object, *, redact: bool) -> Any:
+    if isinstance(value, dict):
+        normalized: dict[str, Any] = {}
+        for key, item in value.items():
+            normalized_key = str(key)
+            if redact and _normalized_result_key(key) in _SENSITIVE_RESULT_KEYS:
+                normalized[normalized_key] = _REDACTED
+            else:
+                normalized[normalized_key] = _normalize_result_value(item, redact=redact)
+        return normalized
+    if isinstance(value, list | tuple):
+        return [_normalize_result_value(item, redact=redact) for item in value]
+    if isinstance(value, str):
+        return _redact_result_text(value) if redact else value
+    if value is None or isinstance(value, bool | int):
+        return value
+    if isinstance(value, float):
+        return value if math.isfinite(value) else str(value)
+    rendered = str(value)
+    return _redact_result_text(rendered) if redact else rendered
+
+
+def _canonical_result_json(value: object) -> str:
+    # ASCII escapes make every normalized JSON value UTF-8 encodable, including
+    # JSON strings containing unpaired surrogate escapes from arbitrary tools.
+    return json.dumps(value, ensure_ascii=True, sort_keys=True, separators=(",", ":"))
+
+
+def _bounded_result(result: object) -> tuple[dict[str, Any], object]:
+    if isinstance(result, str):
+        original_text = result
+        try:
+            parsed = json.loads(result)
+        except json.JSONDecodeError:
+            parsed = {"error": "non-JSON tool result"}
+            stored_text = _redact_result_text(result)
+            parsed_as_json = False
+            representation_type = "text"
+        else:
+            stored_text = _canonical_result_json(_normalize_result_value(parsed, redact=True))
+            parsed_as_json = True
+            representation_type = "json"
+    else:
+        parsed = result
+        original_text = _canonical_result_json(_normalize_result_value(result, redact=False))
+        stored_text = _canonical_result_json(_normalize_result_value(result, redact=True))
+        parsed_as_json = True
+        representation_type = "json"
+
+    original_size = len(original_text.encode("utf-8"))
+    stored_bytes = stored_text.encode("utf-8")
+    truncated = len(stored_bytes) > MAX_STORED_RESULT_BYTES
+    if truncated:
+        stored_text = stored_bytes[:MAX_STORED_RESULT_BYTES].decode("utf-8", errors="ignore")
+        stored_bytes = stored_text.encode("utf-8")
+    return (
+        {
+            "parsed_as_json": parsed_as_json,
+            "representation_type": representation_type,
+            "original_size_bytes": original_size,
+            "stored_size_bytes": len(stored_bytes),
+            "max_stored_size_bytes": MAX_STORED_RESULT_BYTES,
+            "truncated": truncated,
+            "value": stored_text,
+        },
+        parsed,
+    )
+
+
+def _result_summary(result: object, duration_ms: object) -> dict[str, Any]:
+    bounded_result, parsed = _bounded_result(result)
     failed = isinstance(parsed, dict) and bool(parsed.get("error"))
     try:
         elapsed = max(0, int(duration_ms))
     except (TypeError, ValueError):
         elapsed = 0
-    return {"status": "error" if failed else "ok", "exit_code": int(failed), "duration_ms": elapsed}
+    return {
+        "status": "error" if failed else "ok",
+        "exit_code": int(failed),
+        "duration_ms": elapsed,
+        "result": bounded_result,
+    }
 
 
 __all__ = [
+    "MAX_STORED_RESULT_BYTES",
     "abandon_execution",
     "execution_class",
     "parse_metadata",

--- a/tests/guard/gates/test_terminal_policy.py
+++ b/tests/guard/gates/test_terminal_policy.py
@@ -2,7 +2,10 @@
 
 from __future__ import annotations
 
+import copy
 import json
+import threading
+from concurrent.futures import ThreadPoolExecutor
 from pathlib import Path
 
 import pytest
@@ -12,6 +15,7 @@ from plugins.violin_guard import handlers as service
 from plugins.violin_guard.core import bootstrap, schemas, state
 from plugins.violin_guard.core import history as execution_history
 from plugins.violin_guard.core.skill_receipts import SkillViewResult
+from plugins.violin_guard.gates import code_execution_audit
 from plugins.violin_guard.gates import command as guard_command
 from plugins.violin_guard.handlers import ptt_handlers
 from plugins.violin_guard.hooks import (
@@ -569,6 +573,42 @@ def _code(eng, target="10.10.10.10") -> str:
     )
 
 
+def _complete_execute_code_result(
+    eng: Path,
+    result: object,
+    *,
+    tool_call_id: str,
+    source_suffix: str = "",
+) -> tuple[Path, dict, dict, str]:
+    source = _code(eng) + source_suffix
+    manifests_before = set((eng / "evidence" / "executions").glob("*-execute-code.json"))
+    assert (
+        _pre_tool_call_hook(
+            tool_name="execute_code",
+            args={"code": source},
+            session_id="test",
+            tool_call_id=tool_call_id,
+        )
+        is None
+    )
+    new_manifests = (
+        set((eng / "evidence" / "executions").glob("*-execute-code.json")) - manifests_before
+    )
+    assert len(new_manifests) == 1
+    manifest = new_manifests.pop()
+    intent = json.loads(manifest.read_text(encoding="utf-8"))
+    _post_tool_call_hook(
+        tool_name="execute_code",
+        args={"code": source},
+        result=result,
+        duration_ms=3,
+        session_id="test",
+        tool_call_id=tool_call_id,
+    )
+    completed = json.loads(manifest.read_text(encoding="utf-8"))
+    return manifest, intent, completed, source
+
+
 def test_execute_code_requires_valid_metadata(tmp_path) -> None:
     blocked = _pre_tool_call_hook(
         tool_name="execute_code",
@@ -618,15 +658,29 @@ def test_execute_code_is_validated_and_recorded(tmp_path) -> None:
     assert state.sync_credit_remaining(eng, "RECON") == 9
     assert state.has_pending_sync(eng)
 
+    raw_result = '{"result":"ok"}'
     _post_tool_call_hook(
         tool_name="execute_code",
         args={"code": source},
-        result='{"result":"ok"}',
+        result=raw_result,
         duration_ms=42,
         session_id="test",
         tool_call_id="recorded-call",
     )
 
+    completed = json.loads(intent_receipts[0].read_text(encoding="utf-8"))
+    assert completed["audit_id"] == intent["audit_id"]
+    assert completed["source_digest"] == intent["source_digest"]
+    assert completed["command"] == intent["command"]
+    assert completed["result"] == {
+        "parsed_as_json": True,
+        "representation_type": "json",
+        "original_size_bytes": len(raw_result.encode("utf-8")),
+        "stored_size_bytes": len(raw_result.encode("utf-8")),
+        "max_stored_size_bytes": code_execution_audit.MAX_STORED_RESULT_BYTES,
+        "truncated": False,
+        "value": raw_result,
+    }
     receipts = list((eng / "evidence" / "executions").glob("*-execute-code.py"))
     assert len(receipts) == 1
     assert receipts[0].read_text(encoding="utf-8") == source
@@ -634,6 +688,8 @@ def test_execute_code_is_validated_and_recorded(tmp_path) -> None:
     assert "execute_code class=target_touching sha256=" in history
     assert "status=completed" in history
     assert "exit_code=0" in history
+    assert completed["evidence_paths"]["manifest"] in history
+    assert raw_result not in history
     pending = state.get_pending_sync(eng)
     assert pending is not None
     pending_command = pending["commands"][0]["command"]
@@ -763,17 +819,272 @@ def test_execute_code_records_tool_errors(tmp_path) -> None:
         )
         is None
     )
+    raw_result = '{"error":"sandbox failed"}'
     _post_tool_call_hook(
         tool_name="execute_code",
         args={"code": source},
-        result='{"error":"sandbox failed"}',
+        result=raw_result,
         duration_ms=7,
         session_id="test",
         tool_call_id="error-call",
     )
+    manifest = next((eng / "evidence" / "executions").glob("*-execute-code.json"))
+    completed = json.loads(manifest.read_text(encoding="utf-8"))
+    assert completed["status"] == "completed_with_error"
+    assert completed["result"]["parsed_as_json"] is True
+    assert completed["result"]["representation_type"] == "json"
+    assert completed["result"]["value"] == raw_result
     history = (eng / "state" / "history.md").read_text(encoding="utf-8")
     assert "status=completed_with_error" in history
     assert "exit_code=1" in history
+
+
+def test_execute_code_redacts_nested_secrets_without_mutating_input(tmp_path) -> None:
+    eng = _engagement(tmp_path)
+    private_key = (
+        "-----BEGIN PRIVATE KEY-----\nprivate-key-material-1234567890\n-----END PRIVATE KEY-----"
+    )
+    jwt = "eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiIxMjM0NTY3ODkwIn0.signaturevalue"
+    result = {
+        "safe": "visible",
+        "nested": [
+            {
+                "password": "password-value-123",
+                "passwd": "passwd-value-123",
+                "secret": "secret-value-123",
+                "token": "token-value-123",
+                "access_token": "access-value-123",
+                "refresh_token": "refresh-value-123",
+            },
+            {
+                "api_key": "api-key-value-123",
+                "apikey": "apikey-value-123",
+                "authorization": "Bearer structured-auth-value-123",
+                "cookie": "session=cookie-value-123",
+                "set-cookie": "sid=set-cookie-value-123",
+            },
+            {
+                "message": "Authorization: Bearer loose-bearer-value-123",
+                "jwt_value": jwt,
+                "provider_value": "sk-live-provider-token-value-1234567890",
+                "private_material": private_key,
+            },
+        ],
+    }
+    original = copy.deepcopy(result)
+
+    manifest, _intent, completed, _source = _complete_execute_code_result(
+        eng,
+        result,
+        tool_call_id="nested-redaction",
+    )
+
+    assert result == original
+    result_record = completed["result"]
+    assert result_record["parsed_as_json"] is True
+    assert result_record["representation_type"] == "json"
+    assert result_record["truncated"] is False
+    assert result_record["original_size_bytes"] == len(
+        json.dumps(
+            original,
+            ensure_ascii=False,
+            sort_keys=True,
+            separators=(",", ":"),
+        ).encode("utf-8")
+    )
+    assert result_record["stored_size_bytes"] == len(result_record["value"].encode("utf-8"))
+    stored = json.loads(result_record["value"])
+    assert stored["safe"] == "visible"
+    for key in (
+        "password",
+        "passwd",
+        "secret",
+        "token",
+        "access_token",
+        "refresh_token",
+    ):
+        assert stored["nested"][0][key] == "[REDACTED]"
+    for key in ("api_key", "apikey", "authorization", "cookie", "set-cookie"):
+        assert stored["nested"][1][key] == "[REDACTED]"
+    assert "loose-bearer-value-123" not in stored["nested"][2]["message"]
+    assert stored["nested"][2]["jwt_value"] == "[REDACTED_JWT]"
+    assert stored["nested"][2]["provider_value"] == "[REDACTED_TOKEN]"
+    assert stored["nested"][2]["private_material"] == "[REDACTED_PRIVATE_KEY]"
+
+    persisted = manifest.read_text(encoding="utf-8")
+    history = (eng / "state" / "history.md").read_text(encoding="utf-8")
+    for secret in (
+        "password-value-123",
+        "passwd-value-123",
+        "secret-value-123",
+        "token-value-123",
+        "access-value-123",
+        "refresh-value-123",
+        "api-key-value-123",
+        "apikey-value-123",
+        "structured-auth-value-123",
+        "cookie-value-123",
+        "set-cookie-value-123",
+        "loose-bearer-value-123",
+        jwt,
+        "sk-live-provider-token-value-1234567890",
+        "private-key-material-1234567890",
+    ):
+        assert secret not in persisted
+        assert secret not in history
+
+
+@pytest.mark.parametrize(
+    ("raw_result", "secret"),
+    [
+        ('prefix {"password":"dummy-password-123"}', "dummy-password-123"),
+        ('{"access_token":"dummy-access-token-123", invalid}', "dummy-access-token-123"),
+        (
+            '{"authorization":"Basic dummy-authorization-123", invalid}',
+            "dummy-authorization-123",
+        ),
+        ("cookie=dummy-cookie-123", "dummy-cookie-123"),
+        ('{"set-cookie":"sid=dummy-set-cookie-123", invalid}', "dummy-set-cookie-123"),
+        ('{"private_key":"dummy-private-key-123", invalid}', "dummy-private-key-123"),
+        (
+            "prefix -----BEGIN PRIVATE KEY-----\ndummy-partial-private-key-123",
+            "dummy-partial-private-key-123",
+        ),
+    ],
+    ids=[
+        "quoted-password",
+        "quoted-access-token",
+        "quoted-authorization",
+        "cookie-assignment",
+        "quoted-set-cookie",
+        "quoted-private-key",
+        "partial-private-key",
+    ],
+)
+def test_execute_code_redacts_named_secrets_in_non_json_text(
+    tmp_path,
+    raw_result,
+    secret,
+) -> None:
+    eng = _engagement(tmp_path)
+
+    manifest, _intent, completed, _source = _complete_execute_code_result(
+        eng,
+        raw_result,
+        tool_call_id="non-json-secret-redaction",
+    )
+
+    assert completed["status"] == "completed_with_error"
+    assert completed["result"]["parsed_as_json"] is False
+    assert secret not in completed["result"]["value"]
+    assert secret not in manifest.read_text(encoding="utf-8")
+
+
+def test_execute_code_normalizes_unpaired_json_surrogate(tmp_path) -> None:
+    eng = _engagement(tmp_path)
+    raw_result = r'"\ud800"'
+
+    manifest, _intent, completed, _source = _complete_execute_code_result(
+        eng,
+        raw_result,
+        tool_call_id="unpaired-json-surrogate",
+    )
+
+    assert completed["status"] == "completed"
+    assert completed["result"]["parsed_as_json"] is True
+    assert completed["result"]["representation_type"] == "json"
+    assert completed["result"]["value"] == raw_result
+    assert json.loads(manifest.read_text(encoding="utf-8"))["result"] == completed["result"]
+
+
+@pytest.mark.parametrize(
+    ("raw_result", "parsed_as_json", "representation_type", "expected_value", "status"),
+    [
+        ("plain non-JSON result", False, "text", "plain non-JSON result", "completed_with_error"),
+        ("", False, "text", "", "completed_with_error"),
+        (None, True, "json", "null", "completed"),
+    ],
+)
+def test_execute_code_persists_non_json_and_empty_results(
+    tmp_path,
+    raw_result,
+    parsed_as_json,
+    representation_type,
+    expected_value,
+    status,
+) -> None:
+    eng = _engagement(tmp_path)
+
+    _manifest, _intent, completed, _source = _complete_execute_code_result(
+        eng,
+        raw_result,
+        tool_call_id=f"result-shape-{representation_type}-{type(raw_result).__name__}",
+    )
+
+    result_record = completed["result"]
+    original_text = raw_result if isinstance(raw_result, str) else "null"
+    assert completed["status"] == status
+    assert result_record["parsed_as_json"] is parsed_as_json
+    assert result_record["representation_type"] == representation_type
+    assert result_record["original_size_bytes"] == len(original_text.encode("utf-8"))
+    assert result_record["stored_size_bytes"] == len(expected_value.encode("utf-8"))
+    assert result_record["truncated"] is False
+    assert result_record["value"] == expected_value
+
+
+@pytest.mark.parametrize(
+    ("raw_result", "parsed_as_json", "representation_type"),
+    [
+        (
+            json.dumps(
+                {
+                    "password": "oversized-secret-value",
+                    "payload": "é" * (33 * 1024),
+                },
+                ensure_ascii=False,
+            ),
+            True,
+            "json",
+        ),
+        ("plain:" + "é" * (33 * 1024), False, "text"),
+    ],
+    ids=["json", "text"],
+)
+def test_execute_code_truncates_oversized_results_deterministically(
+    tmp_path,
+    raw_result,
+    parsed_as_json,
+    representation_type,
+) -> None:
+    eng = _engagement(tmp_path)
+
+    first_manifest, _first_intent, first, _first_source = _complete_execute_code_result(
+        eng,
+        raw_result,
+        tool_call_id=f"oversized-{representation_type}-first",
+        source_suffix="print('first oversized result')\n",
+    )
+    second_manifest, _second_intent, second, _second_source = _complete_execute_code_result(
+        eng,
+        raw_result,
+        tool_call_id=f"oversized-{representation_type}-second",
+        source_suffix="print('second oversized result')\n",
+    )
+
+    first_record = first["result"]
+    second_record = second["result"]
+    assert first_record["parsed_as_json"] is parsed_as_json
+    assert first_record["representation_type"] == representation_type
+    assert first_record["original_size_bytes"] == len(raw_result.encode("utf-8"))
+    assert first_record["max_stored_size_bytes"] == code_execution_audit.MAX_STORED_RESULT_BYTES
+    assert first_record["truncated"] is True
+    assert first_record["stored_size_bytes"] == len(first_record["value"].encode("utf-8"))
+    assert first_record["stored_size_bytes"] <= code_execution_audit.MAX_STORED_RESULT_BYTES
+    assert second_record["value"] == first_record["value"]
+    assert second_record["stored_size_bytes"] == first_record["stored_size_bytes"]
+    assert second_record["truncated"] is True
+    assert "oversized-secret-value" not in first_manifest.read_text(encoding="utf-8")
+    assert "oversized-secret-value" not in second_manifest.read_text(encoding="utf-8")
 
 
 def test_execute_code_requires_tool_call_id_before_writing_intent(tmp_path) -> None:
@@ -785,6 +1096,46 @@ def test_execute_code_requires_tool_call_id_before_writing_intent(tmp_path) -> N
         "message": "execute_code requires Hermes tool_call_id for receipt correlation",
     }
     assert not list((eng / "evidence" / "executions").glob("*-execute-code.json"))
+
+
+def test_execute_code_mismatched_completion_abandons_without_result(tmp_path) -> None:
+    class ResultMustNotBeInspected:
+        marker = "must-not-be-persisted"
+
+        def __str__(self) -> str:
+            raise AssertionError("mismatched completion result was inspected")
+
+    eng = _engagement(tmp_path)
+    source = _code(eng)
+    assert (
+        _pre_tool_call_hook(
+            tool_name="execute_code",
+            args={"code": source},
+            session_id="test",
+            tool_call_id="mismatched-completion",
+        )
+        is None
+    )
+    manifest = next((eng / "evidence" / "executions").glob("*-execute-code.json"))
+    intent = json.loads(manifest.read_text(encoding="utf-8"))
+
+    with pytest.raises(ValueError, match="does not match its intent receipt"):
+        _post_tool_call_hook(
+            tool_name="execute_code",
+            args={"code": source + "# changed after dispatch\n"},
+            result=ResultMustNotBeInspected(),
+            duration_ms=9,
+            session_id="test",
+            tool_call_id="mismatched-completion",
+        )
+
+    abandoned = json.loads(manifest.read_text(encoding="utf-8"))
+    assert abandoned["status"] == "abandoned"
+    assert abandoned["audit_id"] == intent["audit_id"]
+    assert abandoned["source_digest"] == intent["source_digest"]
+    assert abandoned["command"] == intent["command"]
+    assert "result" not in abandoned
+    assert "must-not-be-persisted" not in manifest.read_text(encoding="utf-8")
 
 
 def test_parallel_execute_code_calls_correlate_by_tool_call_id(tmp_path) -> None:
@@ -811,31 +1162,118 @@ def test_parallel_execute_code_calls_correlate_by_tool_call_id(tmp_path) -> None
         is None
     )
 
-    _post_tool_call_hook(
-        tool_name="execute_code",
-        args={"code": first},
-        result='{"result":"first"}',
-        duration_ms=11,
-        session_id="test",
-        tool_call_id="parallel-1",
-    )
-    _post_tool_call_hook(
-        tool_name="execute_code",
-        args={"code": second},
-        result='{"result":"second"}',
-        duration_ms=22,
-        session_id="test",
-        tool_call_id="parallel-2",
-    )
+    def complete(source: str, result: str, duration_ms: int, tool_call_id: str) -> None:
+        _post_tool_call_hook(
+            tool_name="execute_code",
+            args={"code": source},
+            result=result,
+            duration_ms=duration_ms,
+            session_id="test",
+            tool_call_id=tool_call_id,
+        )
+
+    with ThreadPoolExecutor(max_workers=2) as pool:
+        futures = [
+            pool.submit(complete, first, '{"result":"first"}', 11, "parallel-1"),
+            pool.submit(complete, second, '{"result":"second"}', 22, "parallel-2"),
+        ]
+        for future in futures:
+            future.result()
 
     receipts = [
         json.loads(path.read_text(encoding="utf-8"))
         for path in (eng / "evidence" / "executions").glob("*-execute-code.json")
     ]
-    assert sorted((receipt["status"], receipt["duration_ms"]) for receipt in receipts) == [
-        ("completed", 11),
-        ("completed", 22),
-    ]
+    expected = {
+        code_execution_audit.source_digest(first): ("first", 11),
+        code_execution_audit.source_digest(second): ("second", 22),
+    }
+    assert len(receipts) == 2
+    for receipt in receipts:
+        expected_value, expected_duration = expected[receipt["source_digest"]]
+        assert receipt["status"] == "completed"
+        assert receipt["duration_ms"] == expected_duration
+        assert json.loads(receipt["result"]["value"])["result"] == expected_value
+
+
+def test_execute_code_concurrent_completions_preserve_first_terminal_result(tmp_path) -> None:
+    eng = _engagement(tmp_path)
+    source = _code(eng) + "print('completion race')\n"
+    _metadata, manifest = code_execution_audit.prepare_execution(source)
+    intent = json.loads(manifest.read_text(encoding="utf-8"))
+    start = threading.Barrier(2)
+
+    def complete(value: str) -> None:
+        start.wait()
+        code_execution_audit.record_completion(
+            source,
+            {"result": value},
+            5,
+            receipt_path=manifest,
+        )
+
+    with ThreadPoolExecutor(max_workers=2) as pool:
+        futures = [pool.submit(complete, "first"), pool.submit(complete, "second")]
+        errors = []
+        for future in futures:
+            try:
+                future.result()
+            except ValueError as exc:
+                errors.append(str(exc))
+
+    assert len(errors) == 1
+    assert "already finalized" in errors[0]
+    terminal = json.loads(manifest.read_text(encoding="utf-8"))
+    assert terminal["status"] == "completed"
+    assert terminal["audit_id"] == intent["audit_id"]
+    assert terminal["source_digest"] == intent["source_digest"]
+    assert terminal["command"] == intent["command"]
+    assert json.loads(terminal["result"]["value"])["result"] in {"first", "second"}
+    history = (eng / "state" / "history.md").read_text(encoding="utf-8")
+    assert history.count(manifest.relative_to(eng).as_posix()) == 1
+
+
+def test_execute_code_completion_and_abandonment_serialize_one_terminal_manifest(tmp_path) -> None:
+    eng = _engagement(tmp_path)
+    source = _code(eng) + "print('completion race')\n"
+    _metadata, manifest = code_execution_audit.prepare_execution(source)
+    intent = json.loads(manifest.read_text(encoding="utf-8"))
+    start = threading.Barrier(2)
+
+    def complete() -> None:
+        start.wait()
+        code_execution_audit.record_completion(
+            source,
+            {"result": "completed"},
+            5,
+            receipt_path=manifest,
+        )
+
+    def abandon() -> None:
+        start.wait()
+        code_execution_audit.abandon_execution(manifest, "concurrent abandonment")
+
+    with ThreadPoolExecutor(max_workers=2) as pool:
+        futures = [pool.submit(complete), pool.submit(abandon)]
+        errors = []
+        for future in futures:
+            try:
+                future.result()
+            except ValueError as exc:
+                errors.append(str(exc))
+
+    assert not errors or all("already finalized" in error for error in errors)
+    terminal = json.loads(manifest.read_text(encoding="utf-8"))
+    assert terminal["status"] in {"completed", "abandoned"}
+    assert terminal["audit_id"] == intent["audit_id"]
+    assert terminal["source_digest"] == intent["source_digest"]
+    assert terminal["command"] == intent["command"]
+    if terminal["status"] == "completed":
+        assert json.loads(terminal["result"]["value"])["result"] == "completed"
+    else:
+        assert "result" not in terminal
+    history = (eng / "state" / "history.md").read_text(encoding="utf-8")
+    assert history.count(manifest.relative_to(eng).as_posix()) == 1
 
 
 def test_session_finalize_abandons_unfinished_execute_code_receipt(tmp_path) -> None:
@@ -856,6 +1294,7 @@ def test_session_finalize_abandons_unfinished_execute_code_receipt(tmp_path) -> 
     manifest = next((eng / "evidence" / "executions").glob("*-execute-code.json"))
     receipt = json.loads(manifest.read_text(encoding="utf-8"))
     assert receipt["status"] == "abandoned"
+    assert "result" not in receipt
     with pytest.raises(ValueError, match="intent receipt is missing for tool_call_id"):
         _post_tool_call_hook(
             tool_name="execute_code",


### PR DESCRIPTION
## Summary

- Persist a normalized `result` record in each completed `execute_code` audit manifest.
- Bound the stored value to 32 KiB (`32768` bytes), reusing the executor's existing `PREVIEW_BYTES` budget so audit bodies cannot grow without limit.
- Serialize completion and abandonment with the existing per-file lock and atomic JSON writer, preventing concurrent terminal updates from overwriting one another.

The additive manifest structure is:

```json
{
  "result": {
    "parsed_as_json": true,
    "representation_type": "json",
    "original_size_bytes": 123,
    "stored_size_bytes": 101,
    "max_stored_size_bytes": 32768,
    "truncated": false,
    "value": "..."
  }
}
```

JSON values are canonicalized with sorted keys and compact, ASCII-safe encoding. Non-JSON output remains text. Redaction runs before deterministic UTF-8 truncation, and no unbounded raw result is copied elsewhere in the manifest.

## Redaction policy

- Recursively copy dictionaries and lists without mutating the caller's result object.
- Redact case-insensitive named fields after hyphen/whitespace normalization: `password`, `passwd`, `secret`, `token`, `access_token`, `refresh_token`, `api_key`, `apikey`, `authorization`, `cookie`, `set-cookie`, and `private_key`.
- Apply the same explicit field policy to plain or malformed text, including quoted field names and `:`/`=` assignments.
- Redact complete or partial PEM private-key blocks, Authorization/Bearer values, Cookie/Set-Cookie values, JWTs, and common `sk-`, GitHub `gh*_`, and Slack `xox*-` token forms.

## Integrity

- Source digest, audit ID, and command identity remain byte-for-byte stable from intent to completion.
- Receipt digest/status/command validation happens before result inspection and remains fail-closed for mismatched intent receipts.
- Pending batch reconciliation is unchanged.
- History continues to contain only the manifest reference; result bodies are not duplicated there.
- Completion/completion and completion/abandonment races are serialized under the receipt lock; writes remain atomic.

## Tests

- Focused: `uv run pytest -q tests/guard/gates/test_terminal_policy.py -k execute_code` — **29 passed, 66 deselected in 4.31s**.
- Full post-commit suite: `uv run pytest` — **496 passed in 57.58s**.
- `uv run ruff check .` — **All checks passed**.
- `uv run ruff format --check .` — **106 files already formatted**.
- `uv run python scripts/violin_guard.py check-release` — **all release checks passed**, including its internal Ruff and test-suite gates.
- `git diff --check` and `git diff --check dev...HEAD` — **passed**.

All Python verification ran on Linux in the official `ghcr.io/astral-sh/uv:python3.11-trixie-slim` container.

Closes #12
