### PR TITLE
feat: practitioner landing page, technical whitepapers, and README tool-list fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,9 +4,16 @@
 
 ### Added
 
-- Landing page for the project with the guard flow, registered tool surface, routed playbooks, and stated limits.
+- Landing page aimed at working testers: how the guard works, an engagement walkthrough, an approach
+  comparison, coverage, honest limits, and the questions testers actually ask.
 - Repository social preview card so shared links unfurl with the project identity.
 - GitHub Discussions as the community surface for playbook requests, setup questions, and engagement feedback.
+- Operator-facing articles under `docs/articles/` on guardrails, coverage discipline, and how to evaluate an
+  agentic pentest tool, plus `PROMOTION.md` as the launch and outreach kit.
+
+### Fixed
+
+- README registered-tool list now includes `violin_submit_finding` and states the correct count of twelve.
 
 ### Changed
 

--- a/PROMOTION.md
+++ b/PROMOTION.md
@@ -1,0 +1,482 @@
+# Violin Launch Kit (PROMOTION.md)
+
+A copy-paste playbook for promoting Violin, the supervised agentic pentest profile for Hermes Agent. Every post below is finished copy. The only gaps are things only you know, marked `[[...]]`.
+
+---
+
+## How to use this kit
+
+1. Read the "Repo facts cheat sheet" below and keep it pinned while you post. Every hard number in this kit is grounded in the repo files: README.md, docs/BENCHMARKS.md, CHANGELOG.md, SECURITY.md, CONTRIBUTING.md, and the skill playbooks. Do not invent beyond them.
+2. Run the 10-day sequence in section 2. It is ordered so content lands first, then the high-signal post (Hacker News), then communities, so there is material to link back to.
+3. Copy posts verbatim per platform. Edit only the `[[...]]` slots.
+4. Never post about targeting any system you do not own or lack written authorization to test. No client data, no engagement evidence, no real-target detail. Example targets stay in your local lab or deliberately vulnerable apps (section 12).
+5. Track the numbers in section 10 weekly and cut channels that produce nothing after three attempts.
+
+---
+
+## Repo facts cheat sheet
+
+| Field | Value |
+|---|---|
+| Name | Violin |
+| One-liner | An open-source, supervised agentic penetration-testing profile for Hermes Agent with a required execution guard, evidence-backed findings, and engagement state that survives context compression. |
+| Install | `hermes profile install https://github.com/Strategic-Automation/violin` |
+| License | MIT (Copyright (c) 2026 Violin contributors) |
+| Requirements | Hermes Agent 0.18.0+, Python 3.11 + `uv` for dev, Kali Linux or Parrot OS, written authorization and an approved scope |
+| Current stars | 88 |
+| Version | 3.2.1 |
+| Surface | 12 registered tools, 7 routed skills, 35 playbooks (verified: 9 pentest + 13 web-app + 6 identity-auth + 1 api-testing + 1 business-logic + 2 llm-security + 3 misconfig), 19 references, 15 templates |
+| Repo | https://github.com/Strategic-Automation/violin |
+| Docs | https://hermes-agent.nousresearch.com (host platform); BENCHMARKS.md for the only documented benchmark claims |
+| Benchmark status | The repo publishes its benchmark methodology and treats a single agentic run as a noisy sample. No live agent score is documented, so claim none. |
+| Maintainer org | Strategic Automation Ltd (sponsor link in README) |
+
+Important framing rule: the repository documents that a single agentic run is a noisy sample and that calibration is not a live benchmark result (docs/BENCHMARKS.md). Never post a "Violin scored X/20" figure; it is not in the repo.
+
+---
+
+## 1. Positioning + the one-liner
+
+**The one-liner** (use verbatim in bios, signatures, and directory descriptions):
+
+> Violin is an open-source, MIT-licensed Hermes Agent profile that runs authorization-scoped penetration tests where every target-touching command passes a required execution guard, gets a signed receipt, and feeds evidence-backed findings and reports.
+
+**Three core talking points** (build every post around one or two of these):
+
+1. **The guard is required, not a soft confirm.** Before a target command runs, `violin-exec` checks scope, phase, the active PTT task, the routed skill, the hypothesis, and execution history. Denials fail closed and give the operator the exact typed tool call needed to proceed. This is accountable AI-assisted testing, not a wrapper around a chat model with shell access.
+2. **Findings are evidence-backed.** A validated finding must bind to signed execution receipts. The report is derived from receipt-backed evidence, not model prose. For consulting and audit, that is the difference between "the tool says so" and "here is the request, the response, and the receipt that authenticate it."
+3. **Engagement state survives context compression.** PTT tasks, hypotheses, checkpoints, and evidence resume from engagement files when the conversation is compacted. Long engagements do not lose the plot.
+
+**Three objections to expect** (answered copy in sections 3 and 11):
+
+1. "This is just ChatGPT or Claude handed a shell. What is actually new?"
+2. "AI pentesting is a gimmick; it just writes pretty reports."
+3. "Is it safe? How do I know it won't hit things out of scope?"
+
+---
+
+## 2. Timing + sequencing (10-day plan)
+
+Order matters: content first establishes the story, then the single most-important post (Hacker News) points at it, then communities amplify, then directories and outreach consolidate searchable presence.
+
+**Why this order.** Hacker News is the highest-leverage single post because its audience is exactly your users (builders who maintain the tooling Violin routes to, and people who have tried and been burned by agentic tools). One good Show HN drives more installs and GitHub-following attention than anything else here, and its comments become the FAQ you reuse everywhere else. Communities and newsletters amplify after HN exists to link to, because there is then a public discussion to reference. Directories are low-effort SEO tail and can be done in parallel.
+
+| Day | Action | Why this slot |
+|---|---|---|
+| Day 1 | Publish the 4-article content base (section 7, posts 1-2 at minimum) | Content ready before anything links to it |
+| Day 2-3 | Show HN post + author context comment (section 3). Plan to check replies for 3-5 hours after posting | HN is the single most important post; do it when you can be present to engage |
+| Day 4 | X thread + standalone post (section 5) | Ride any HN interest; link the article that survived contact |
+| Day 5 | r/netsec technical write-up (section 4) | Deliberately separated from HN to avoid "spamming every channel on day 1" |
+| Day 6-7 | Remaining subreddit posts (section 4), one community per subreddit, spaced out | Avoid flooding; each subreddit gets a distinct angle, not the same link 6 times |
+| Day 8 | LinkedIn post + comment (section 6); directories: Product Hunt, AlternativeTo (section 9) | Professional + SEO surfaces |
+| Day 9 | Newsletter + podcast + YouTuber pitches (section 8) | Time for them to respond after the public discussion exists |
+| Day 10 | Build-in-public cadence begins (section 7 posts 3-4); measure first week (section 10) | Turn launch into a habit |
+
+**What to avoid:**
+
+- Do NOT post the same link to six subreddits in one hour. It reads as spam and gets you banned. Space subreddit posts over days and vary the copy and angle per subreddit.
+- Do NOT lead with "I built X, try it!" anywhere. Lead with the problem or the engineering.
+- Do NOT repeat the exact one-liner in every post; it reads templated. Vary emphasis per channel.
+- Do NOT claim a benchmark score. The repo documents no live score, only calibration.
+- Do NOT present yourself as anything but the maintainer. Disclose authorship in every community post (native on HN, mandatory on Reddit, natural on LinkedIn).
+
+**The single post that matters most: Hacker News.** It is the one that reaches your actual target user at scale, produces durable criticism you can fold into the roadmap, and gives every other channel a credible third-party discussion to link to. Budget the most time there.
+
+---
+
+## 3. Hacker News
+
+### Show HN title (primary, <= 80 chars)
+
+`Show HN: Violin – a guarded, supervised agentic pentest profile for Hermes`
+
+(44 chars of that is the title core; the "Show HN:" prefix and punctuation keep it under 80.)
+
+### 5 alternate titles
+
+1. `Show HN: Violin – agentic pentesting with a required execution guard`
+2. `Show HN: An agentic pentest profile where every command needs a signed receipt`
+3. `Show HN: I built an LLM pentester that fails closed on scope`
+4. `Show HN: Receipt-backed findings for AI-assisted penetration testing`
+5. `Show HN: Supervised agentic recon-to-report pentesting, MIT licensed`
+
+### First comment (the author's context comment), 150-250 words
+
+Target: about 210 words.
+
+> Author here. Violin is an MIT-licensed profile for Hermes Agent that runs authorized penetration tests from reconnaissance through exploit validation to reporting. The thing I want pressure-tested is the guard, not the model.
+>
+> Every command that touches a target passes through a required execution guard before it runs. The guard checks scope, the current phase, the active PTT task, the routed skill, the stated hypothesis, and execution history, and it fails closed with the exact typed tool call you need to proceed. Findings are bound to signed execution receipts, so a report is "here is the request, here is the response, here is the receipt authenticating both," not "the model said so." Engagement state is written to disk, so PTT tasks, hypotheses, and checkpoints survive context compression.
+>
+> Honest limits. The repo ships a benchmark harness and documents its methodology, but it publishes no live agent score, because a single agentic run is a noisy sample. If I post a number it will be a distribution across repeated runs, per docs/BENCHMARKS.md. A harness that runs is not the same thing as a tool that reliably finds bugs, and I am not going to pretend otherwise.
+>
+> It is for authorized testing only, and the guard enforces that by policy.
+>
+> What I want back: (1) is the required-guard model actually usable in a real engagement, or is it friction without value? (2) Which vulnerability classes are least reliable and worth playbooks? The README and install command are in the repo.
+
+### Pre-written answers to the four standard skeptics
+
+**Q: "How is this different from just using Claude or GPT with shell access?"**
+> Fair question. The difference is the enforcement boundary, not the model. Prompt a general agent and it will try things and hope it stays in scope; if you want guardrails you bolt them on afterwards and they are advisory. Violin sits in the tool layer, not the prompt layer. A target command cannot run unless the guard validates scope, phase, task, skill, hypothesis and history against schema-validated state, and fails closed. It also gives you verifiable artifacts: each execution gets a signed receipt and findings are bound to those receipts. So the answer to "did it actually do this" is a file, not a claim. You are right that the underlying model is interchangeable; read the README, it says the same thing. The profile deliberately does not pick a model or provider.
+
+**Q: "AI pentesting is a gimmick, it just writes reports."**
+> The report-writing part is close to the least useful thing it does, so I'll grant the skepticism and pivot. The value I am claiming is different: enforced methodology and auditable evidence. It will not let you skip from recon to exploitation without a valid phase task, and it will not credit a finding that lacks a signed execution receipt. The report generator derives findings.yaml and the closeout from verified FIND-NNN artifacts, not from prose. So if your objection is "LLMs hallucinate confident narratives," Violin is built so that a confident claim with no receipt gets zero credit. That is a testable property, and docs/BENCHMARKS.md documents how evidence is separated from report prose.
+
+**Q: "What about scope violations? Is this safe?"**
+> Scope enforcement is the core design, so this is the right thing to stress. The guard parses commands with AST-based tooling (bashlex, yarl, netaddr) to resolve hosts, URLs, IP/CIDR and compound commands, and it denies anything outside the approved scope target, fail-closed, with the exact next step. It will not run a target command at all until scope approval and bootstrap validation pass. It blocks destructiveness, disruption, credential access, persistence, stealth, and anything affecting third parties without explicit written authorization. Two caveats I want to state plainly: the raw-terminal hook is a best-effort safety net, not network containment, and this is for targets you own or have written authorization for. Nothing here removes operator responsibility.
+
+**Q: "Isn't the benchmark self-serving or unreal?"**
+> I understand why it reads that way, and I've tried to make it hard to hide behind. Two things. First, the repo does not publish a live score at all, precisely because a one-off agentic run is noise; the methodology in docs/BENCHMARKS.md documents the non-determinism doctrine and says to report mean pass@1 across at least three runs, not the best run. Second, the evaluation does not score report prose: only receipt-backed findings are considered, and the receipts are authenticated before they count. So the incentive is to make the evidence honest, because a pretty report with no receipt earns nothing.
+
+---
+
+## 4. Reddit
+
+General rules that apply to every post:
+- Disclose you are the maintainer in the first or second line. Reddit penalizes undisclosed self-promotion; disclosed self-posts with substance are tolerated.
+- Do not use the same title or body in more than two subreddits, and wait at least a day between different subreddits.
+- Do not drop the raw install command as the entire post. Lead with substance, link the repo once.
+
+### r/netsec (reception + rules)
+
+Note: **r/netsec rejects tool announcements as submissions.** A bare "I made a pentest tool, here is the repo" will be removed. The submission must be a substantive technical write-up that leads with an engineering problem. Post it as a technical article, not a link to the repo. Keep audience tone professional, first-person-plural, no hype.
+
+**Title:**
+`Scope enforcement in an agentic penetration-testing loop`
+
+**Body (self-post):**
+> A model given shell access will, sooner or later, run something it should not. Prompting discipline does not fix this, because the failure mode is orthogonal to instruction following: the model confidently acts on a target assumption that is wrong, and there is no enforcement point between intent and execution. This is a design post about putting an enforcement boundary in the tool layer rather than the prompt layer, in the context of an open-source, authorization-scoped agentic pentest profile (MIT). Disclosure: I maintain it. Repo link at the end.
+>
+> The boundary is a required execution guard between the agent and every command that touches a target. Before a command runs, the guard validates, against schema-validated engagement state: the approved scope (host, URL, IP/CIDR, with exclusions), the current phase, the active PTT task under that phase, the routed skill, the stated hypothesis, and execution history. Compound commands are parsed with AST tooling (bashlex, yarl, netaddr) so pipelines, subshells, and redirections are checked independently rather than against a regex of "allowed binaries." There is no binary allowlist by design, because allowlists rot; the scope and phase gates are the invariant.
+>
+> The evaluation side is worth attention too. Findings are only credited when they bind to a signed execution receipt, and the evaluation reads only receipt-backed evidence, never report prose, so a confident narrative with no evidence earns zero. The project also refuses to treat a working harness as a live benchmark, because a single agentic run is a noisy sample.
+>
+> Open questions I would like this community's take on: is a hard guard in the tool layer net-positive on a real engagement, or is the friction unacceptable before a second model provider arrives? And are AST-based scope parsers enough, or do we need network-layer containment to make an honesty claim? Repo: https://github.com/Strategic-Automation/violin (MIT, install via `hermes profile install` as a Hermes Agent profile).
+
+### r/cybersecurity
+
+**Reception:** broad professional + student audience, tolerant of open source projects if the post has substance and a clear disclosure. Titles should frame value for practitioners, not enthusiasts.
+
+**Title:**
+`I built an open-source, authorization-scoped agentic pentest profile. Here is how it enforces scope.`
+
+**Body:**
+> Maintainer here, disclosure up front. I release a lot of security tooling, and most of the questions I get are not "does it find anything" but "will this run something I did not authorize." So I built the enforcement into the tool rather than into a prompt.
+>
+> Violin is an MIT-licensed profile for Hermes Agent that runs an authorized assessment from recon to reporting. Every command that could touch the target passes a required guard first. The guard checks the approved scope against the resolved host, URL, IP/CIDR with exclusions; checks the current phase against the active PTT task; checks the routed skill and hypothesis; and rejects anything that fails, closed, with the exact next step. Commands are parsed with an AST, so a pipeline or subshell does not slip past a keyword check. Findings bind to signed execution receipts, so the report is auditable: request, response, and receipt.
+>
+> It is deliberately not a stance on "AI can replace testers." It is an attempt to make AI-assisted testing accountable enough that a consultant can hand a client a defensible chain of evidence. It is also honest about its limits: the repo documents benchmark methodology and calibration, but no live score, because single agentic runs are noise.
+>
+> Worth a look if you have been burned by LLM tools that produce confident reports with no way to verify them, or if you just want to test the guard model against your own scope policy. Install: `hermes profile install https://github.com/Strategic-Automation/violin`. Only use it on targets you own or have written authorization to test.
+
+### r/AskNetsec
+
+**Reception:** Q&A-focused; direct posts that answer a question people ask do well. A "here is how I solved X" is acceptable with disclosure. Keep it humble and shorter.
+
+**Title:**
+`How do you stop an LLM pentester from running things out of scope? (Built a required guard; feedback welcome)`
+
+**Body:**
+> Maintainer here. Question I keep getting from in-scope work: how do you actually stop an agent with shell access from touching the thing it should not, when a prompt tells it not to and it does anyway? My answer, in an open-source profile I maintain, is to move the check out of the prompt and into the execution path.
+>
+> Before a target command runs, a guard validates scope (resolved host/URL/CIDR plus exclusions against the approved target), the current phase against an active task, the routed skill, the hypothesis, and prior history. Command parsing is AST-based, so `foo; malicious_host` and pipelines are checked as whole structures, not matched against a list of "safe" binaries. The instance fails closed and returns the exact typed call to proceed.
+>
+> It also makes findings auditable: each execution gets a signed receipt and a validated finding must bind to one, so a report is evidence, not an assertion.
+>
+> I would honestly like pushback on two points: is a hard guard in the tool layer the right level, or should containment also be at the network layer to earn a real safety claim? And is the friction acceptable on real engagements? Repo if you want details: https://github.com/Strategic-Automation/violin. It is MIT and installs as `hermes profile install https://github.com/Strategic-Automation/violin`. Authorized targets only.
+
+### r/LLMDevs
+
+**Reception:** constructive engineering crowd that likes typed boundaries, state, and honest evals. Focus on tool-layer enforcement and the benchmark methodology.
+
+**Title:**
+`Mandatory not advisory: enforcing an execution guard in an LLM tool loop`
+
+**Body:**
+> Tool-calling agents that act on the environment have a boundary problem: the model is told "stay in scope," it believes it is, and it acts anyway. Advisory guardrails are instructions; they are not enforcement. For an open-source agentic profile I maintain (MIT, disclosure), I made the guard mandatory at the tool boundary.
+>
+> The architecture: a plugin registers eleven typed Hermes tools. The one that runs a target command (`violin-exec`) is the only path to the target, and it validates scope, phase, active task, routed skill, hypothesis, and history before it will run anything. State is schema-validated on disk and survives context compression, so PTT tasks, hypotheses and checkpoints resume across compacted conversations. Findings must bind to signed execution receipts, which is what makes the eval interesting to me as an LLM-dev thing.
+>
+> The eval side is where I hope LLM developers will engage most. The repo ships a benchmark harness but declines to post a live score. The methodology (docs/BENCHMARKS.md) treats a single run as a noisy sample, requires a distribution rather than a best run, and counts only receipt-backed evidence, which is why report prose cannot talk its way to credit.
+>
+> If you have opinions on where tool-layer enforcement breaks down, or on what a credible agentic security eval looks like, the repo issues and README are open. https://github.com/Strategic-Automation/violin
+
+### r/AI_Agents
+
+**Reception:** focused on agent architectures, reliability, and evaluation. Emphasize state persistence, the guard as an agent control, and honest evaluation. Disclosure required.
+
+**Title:**
+`A required execution guard as an agent control: structural notes + a working open-source example`
+
+**Body:**
+> Disclosure: I maintain the project this references. Posting because I think the control pattern generalizes.
+>
+> For any agent that can touch a real environment, the highest-value control is not better prompting, it is an authoritative gate in tool space. Violin, an MIT agentic pentest profile, implements this as a required guard on the single tool path that can run a target command. The guard validates scope against the resolved request (host, URL, IP/CIDR, exclusions), the phase against an active task, the routed skill, the stated hypothesis, and history, and fails closed with a typed next-step hint. Compound commands are parsed with an AST so the gate sees pipelines and subshells, not just the base binary.
+>
+> Two other choices worth copying: (1) engagement state is persisted schema-validated on disk so context compression does not lose tasks, hypotheses, or checkpoints; (2) outputs are bound to signed receipts and a finding only counts if it carries one. That last one matters for agents where you need verifiability, because it stops a confident narrative from standing in for evidence.
+>
+> Evaluation is handled the same way: only receipt-backed submissions are credited, and the repo publishes methodology rather than a live score, because a single agentic run is a noisy sample (methodology in docs/BENCHMARKS.md). If you build agents for safety-critical or liability-heavy domains, I would be interested in how you handle the enforcement-vs-friction tradeoff. Repo: https://github.com/Strategic-Automation/violin
+
+### r/opensource
+
+**Reception:** welcoming of launch posts with disclosure and a contributability angle. Lead with "new MIT project, help shape it." Contributors and methodology-curious people live here.
+
+**Title:**
+`New MIT project: Violin, a supervised agentic pentest profile for Hermes (contributors welcome)`
+
+**Body:**
+> I just open-sourced a project I have been hardening for a while and I want contributors and early reviewers. Disclosure: maintainer here.
+>
+> Violin is an MIT-licensed profile for Hermes Agent that turns an authorized penetration test into a supervised, auditable workflow: recon, vulnerability research, exploit validation, and reporting, all routed across seven skills and 35 playbooks (web, identity, API, business logic, LLM security, misconfig). The distinguishing piece is a required execution guard between the agent and any target-touching command, plus evidence-backed findings bound to signed receipts. It is built for authorization-scoped work only.
+>
+> It already has a release gate that runs the full test suite, lint, schemas, skill snapshots and doc contracts before anything ships, so the bar for a clean PR is explicit (see CONTRIBUTING.md). Current stack is Python 3.11, Pydantic v2, uv.
+>
+> Where I most want help: new vulnerability-class playbooks, hardening the real-engagement workflow, and honest evaluation runs. If you have wanted to touch an agentic security project without the hype, this is a small, documented codebase. Install: `hermes profile install https://github.com/Strategic-Automation/violin`. Repo: https://github.com/Strategic-Automation/violin
+
+### r/Pentesting
+
+**Reception:** working pentesters; most skeptical of "AI does your job" and most alert to safety framing. Speak their language: auditability, chain of evidence, and honest limits. Do not oversell recall.
+
+**Title:**
+`Supervised agentic pentesting: an open-source profile where findings must carry a signed receipt`
+
+**Body:**
+> Maintainer, disclosure up front. Thread from a working-tester angle, not hype.
+>
+> What interests me about agents in this field is not recall, it is auditability. A report that says "found X, critical" is only worth what the chain of evidence supports. Violin is an MIT profile for Hermes Agent that treats that literally: every target command has to pass a required guard before it runs, and every validated finding has to bind to a signed execution receipt, so the deliverable maps to request, response, and receipt.
+>
+> The guard checks scope against resolved host/URL/IP/CIDR plus exclusions, the current phase against an active task, the routed skill, the hypothesis, and history, and fails closed with the exact next typed call. Command parsing is AST-based so compound commands do not slip past a keyword filter. It routes methodology across seven skills and 35 playbooks and persists engagement state, so you can close a session and resume without losing PTT tasks or evidence.
+>
+> Honest about limits: the repo ships benchmark calibration and methodology, not a live score, because a single agentic run is a noisy sample. It is for authorized targets only and the guard enforces that by policy.
+>
+> If you would put an agent on a real authorized engagement tomorrow, the friction question is the one I want your take on: is a hard guard net-positive, or does it slow you down more than it protects you? Repo: https://github.com/Strategic-Automation/violin
+
+---
+
+## 5. X / Twitter
+
+### Thread (7 posts, each <= 270 chars, numbered)
+
+Post 1:
+**1/** Most "AI pentesting" is a chat model with a shell and a lot of confidence. The output is only as trustworthy as the evidence behind it. That is the problem I set out to solve.
+
+Post 2:
+**2/** The fix is not a better prompt. It is an enforcement boundary in the tool layer. In Violin, an agentic pentest profile for Hermes Agent, every target-touching command must pass a required guard first.
+
+Post 3:
+**3/** The guard validates scope (host, URL, IP/CIDR, exclusions), the current phase, the active task, the routed skill, the hypothesis, and history. Fails closed. No allowlist rot; the scope is the invariant.
+
+Post 4:
+**4/** Findings bind to signed execution receipts. A validated finding means "here is the request, the response, and the receipt authenticating both," not "the model said so." That is what makes it auditable.
+
+Post 5:
+**5/** Engagement state survives context compression. PTT tasks, hypotheses, checkpoints, and evidence resume from disk when the conversation is compacted. Long engagements keep the plot.
+
+Post 6:
+**6/** Honest about evals: the repo ships a benchmark harness and documents its methodology, but publishes no live score. A single agentic run is a noisy sample (docs/BENCHMARKS.md).
+
+Post 7:
+**7/** MIT licensed, installs as a Hermes profile. Recon to report, 7 skills, 35 playbooks. Authorized targets only by design. https://github.com/Strategic-Automation/violin
+
+### Standalone post version (one post, <= 270 chars)
+
+**Highest-leverage standalone:**
+> LLM pentests are only as good as the evidence trail. Violin, an MIT open-source profile for Hermes Agent, requires every target command to pass a scope/phase/task guard and binds findings to signed execution receipts. No live score to oversell, just auditable methodology. https://github.com/Strategic-Automation/violin
+
+Alternate standalone (short, hooky first line):
+> The problem with "AI pentesting" is confidence without receipts. Violin fixes the enforcement boundary, not the prompt. MIT, open source, authorized targets only. https://github.com/Strategic-Automation/violin
+
+---
+
+## 6. LinkedIn
+
+Target: professional security/consulting audience. Tone is client-trust and auditability, not hype. <= 1300 chars.
+
+**Post:**
+> For anyone delivering or buying penetration tests, the weakest link is rarely the test itself. It is the chain of evidence between "a finding exists" and "we can defend this to a client or an auditor."
+>
+> Most LLM-assisted testing adds speed and adds a new problem: a confident narrative with no verifiable trail. When an agent says it found something, how do you prove it in the report?
+>
+> I open-sourced an answer to that specific question. Violin is an MIT-licensed agentic pentest profile for Hermes Agent that treats evidence as a requirement, not an aspiration:
+>
+> - Every command that touches a target passes a required execution guard that validates scope, phase, task, skill, hypothesis, and history before it runs, and fails closed. Out-of-scope activity is not just discouraged, it is blocked at the boundary.
+> - Findings must bind to signed execution receipts. The report maps each validated finding to the request, the response, and the receipt that authenticates both. That is a defensible chain.
+> - Engagement state persists across sessions, so long assessments do not lose tasks, hypotheses, or evidence.
+> - Evaluation is honest by construction. The repo documents its benchmark methodology and treats a single run as a noisy sample. It does not publish a score it cannot stand behind.
+>
+> It routes an assessment across seven skills and 35 playbooks, from recon through reporting, and is built for authorized engagements only, with scope enforcement in the tool layer rather than a prompt.
+>
+> If you have been wary of agentic security tools because they cannot show their work, this is designed to be the exception. It is free, MIT-licensed, and installs as a Hermes profile.
+>
+> https://github.com/Strategic-Automation/violin
+
+**First comment (link + neutral invite):**
+> Full disclosure: I maintain Violin. I would genuinely welcome a skeptical read of the guard and the evidence model, and I will integrate honest criticism into the roadmap. Install and docs in the repo.
+
+---
+
+## 7. dev.to / Hashnode / Medium cross-posting plan
+
+**Where each article goes, canonical handling:**
+
+- Write the canonical article on **dev.to** (easiest canonical + platform traffic) OR **your own blog** if you have one. Set the canonical URL.
+- Hashnode and Medium both support a canonical URL origin tag: set it so you do not split ranking signal or get penalized for duplicates.
+- Post the same body to dev.to and Hashnode/Medium, always with the canonical pointing at one origin. Do not rewrite substantially per platform; SEO sites penalize near-duplicate content without a canonical.
+- **Where:** the r/netsec engineering post (section 4) doubles as your first dev.to article; expand it to full length there.
+- **Tags per platform:**
+  - dev.to: `security`, `pentesting`, `llm`, `opensource`, `ai`
+  - Hashnode: `security`, `pentesting`, `ai`, `opensource`, `linux`
+  - Medium: `cybersecurity`, `penetration-testing`, `artificial-intelligence`, `open-source`, `llm`
+  - Limit dev.to to 4 tags max (it caps at 4); pick `security`, `pentesting`, `llm`, `opensource`.
+
+**6-week, 4-post content calendar:**
+
+**Post 1 (publish Day 1-3) | Channel: dev.to (canonical) + r/netsec.** Title: *"Scope enforcement in an agentic penetration-testing loop."* Outline: why prompt-level guardrails fail at the tool boundary, the required-guard architecture and AST-based command parsing, and how findings bind to signed receipts. Targets: HN recirculation and the r/netsec engineering audience.
+
+**Post 2 (publish ~Day 7) | Channel: dev.to + XP/Reddit (r/AI_Agents, r/LLMDevs).** Title: *"Evidence vs. prose: making an LLM agent show its work."* Outline: the evaluation problem for agentic security tools, why evidence rather than prose has to be the unit of credit, and why a single agentic run is a noisy sample rather than a score. Targets: LLM developers and people tired of unverifiable agent claims.
+
+**Post 3 (publish ~Week 3) | Channel: Hashnode + LinkedIn.** Title: *"What a required execution guard looks like in practice."* Outline: a walkthrough of the guard checks (scope, phase, task, skill, hypothesis, history) with a concrete deny example, and the operator tradeoff between enforcement and friction. Targets: consultants deciding whether this is usable in engagements.
+
+**Post 4 (publish ~Week 5) | Channel: Medium + X.** Title: *"35 playbooks, 7 skills: structuring agentic pentest methodology."* Outline: how recon-to-report methodology is routed across specialist playbooks, and how playbook standards (evidence, stop conditions, blocked actions) keep both the agent and the project honest. Targets: practitioners and new contributors.
+
+---
+
+## 8. Communities + direct outreach
+
+### Community table
+
+| Community | Type | What to post |
+|---|---|---|
+| Hermes Agent community (Discord/forums per docs at hermes-agent.nousresearch.com) | Native home | Announce Violin as a profile, ask for guard feedback, share the Day-1 article. Highest-relevance, lowest-friction. |
+| OWASP chapter channels (local + OWASP Slack/Discord where active) | Security | Share the evidence-driven findings model and the scope-guard design; ask if the trusted-tools methodology is sound. No link spam, contribute to discussion first. |
+| DevSecOps Slack/Discord communities (e.g. DevSecOps, SANS, InfoSec community servers) | Security ops | Post the "evidence vs prose" angle and offer to answer scope-enforcement questions. |
+| /r/netsec etc. | Reddit | Covered in section 4. |
+| Kali Linux / Parrot forums | Tooling | Note Violin works in the Kali/Parrot environment and routes their installed tools; useful for users whose toolchain you integrate with. |
+| LLM agent Discord/Slack (e.g. communities around agent frameworks, LangChain, OpenRouter-user spaces) | AI builders | Share the guard pattern and the state-persistence design; ask how they handle enforcement in agentic systems. |
+| HackerNews | Forum | Section 3. |
+
+### Pitch emails / DMs (each <= 150 words, no attachments, clear ask)
+
+**To a security newsletter (e.g. tldrsec-style):**
+> Subject: Agentic pentest profile with a required execution guard (MIT, open source)
+>
+> Hi, I maintain Violin, an MIT-licensed agentic penetration-testing profile for Hermes Agent. Its key design choice: every target-touching command must pass a required execution guard validating scope, phase, task, skill, hypothesis, and history, and findings must bind to signed execution receipts. It routes recon-to-report methodology across seven skills and 35 playbooks and persists engagement state across context compression.
+>
+> I believe your readers, who follow security tooling, would find the guard and the honest-evidence evaluation worth a look. The repo deliberately publishes no live benchmark score, treating a single agentic run as a noisy sample, which is the kind of rigor your audience tends to respect.
+>
+> Could I send you a short written brief with the repo link and a one-paragraph summary for your next issue? Repo: https://github.com/Strategic-Automation/violin. Happy to answer questions.
+
+**To an AI / LLM newsletter:**
+> Subject: Tool-layer enforcement, not prompt guardrails: an open-source agentic security control
+>
+> Hi, I am the maintainer of Violin, an MIT open-source agentic pentest profile that demonstrates an agent control I think your readers will find interesting: a required execution guard in the tool layer, not another prompt.
+>
+> A target command cannot run unless the guard validates scope, phase, active task, skill, hypothesis, and history, and findings bind to signed receipts, so outputs are verifiable. It also handles context-compression persistence deliberately. It is honest about evals, publishing methodology and calibration but no live score.
+>
+> This pairs naturally with your coverage of agent reliability and evaluation. Could I offer you a one-page technical brief and demo setup for your next edition? Repo: https://github.com/Strategic-Automation/violin. Happy to walk through it live.
+
+**To a podcast (security or AI agent focused):**
+> Subject: Guest/pod candidate: agentic pentesting without the hype, via a required execution guard
+>
+> Hi, I maintain Violin, an MIT open-source agentic pentest profile for Hermes Agent, and I proposed a topic I think fits your show: what actually holds back LLM agents from doing real security work, and whether an enforcement boundary in the tool layer is the answer.
+>
+> On the show I could talk about the required execution guard, evidence-backed findings with signed receipts, why the project refuses to publish a single benchmark score, and what a credible agentic security evaluation would look like. I am happy to be pushed on the "AI pentesting is a gimmick" angle, it is the most productive version of the conversation.
+>
+> Would a 30- to 45-minute segment fit a future slot? Repo for background: https://github.com/Strategic-Automation/violin.
+
+**To a security YouTuber:**
+> Subject: Source material: an open-source agentic pentest profile with an honest-evidence eval
+>
+> Hi, I maintain Violin, an MIT open-source agentic pentest profile for Hermes Agent. It is a good structural subject if you cover security tooling or LLM agents: a required execution guard that blocks out-of-scope commands, findings bound to signed receipts, and a benchmark that deliberately publishes no live score because single agentic runs are noise.
+>
+> Could make a strong "can an LLM actually do pentesting, and how would you know" video, or a tear-down of the guard if you prefer to stress-test it live. Authorized lab targets only, all local.
+>
+> Happy to provide repo access, a short brief, and a demo environment. Repo: https://github.com/Strategic-Automation/violin.
+
+---
+
+## 9. Directories + listings
+
+### AlternativeTo
+
+**Entry copy:**
+> Violin is a supervised, authorization-scoped agentic penetration-testing profile for Hermes Agent. It routes an assessment across seven routed skills and 35 playbooks, from reconnaissance through exploit validation to reporting. Every target-touching command must pass a required execution guard that validates scope, phase, active task, skill, hypothesis, and history and fails closed; findings bind to signed execution receipts, so deliverables are auditable. Engagement state persists across context compression. MIT licensed; for authorized testing only. Winds up alongside: Nessus, OpenVAS, Metasploit (as complements rather than replacements) and CLI pentest frameworks. Categories: penetration-testing, security-audit, ai-tools, open-source.
+
+### Product Hunt
+
+**Tagline (must be <= 60 chars):**
+`Agentic pentesting with a required execution guard and signed evidence`
+
+(that is 72 chars, too long. Use an alternate):
+`Supervised agentic pentesting with signed evidence receipts`
+
+(61 chars, still 1 over. Final pick, counts ~57):
+`Agentic pentest profile with a required scope guard`
+
+(Chip: count: "Agentic pentest profile with a required scope guard" = 55 chars. Good.)
+
+**Description (first comment optional):**
+> Violin is an open-source (MIT) agentic penetration-testing profile for Hermes Agent. It runs an authorized assessment from reconnaissance through exploit validation to reporting, routed across seven skills and 35 playbooks.
+>
+> The distinguishing piece: a required execution guard between the agent and every target-touching command. Before a command runs, the guard validates the approved scope (host, URL, IP/CIDR, exclusions) against the resolved request, the current phase against an active task, the routed skill, the hypothesis, and history, and it fails closed with the exact next typed step. Findings must bind to signed execution receipts, so the report maps to request, response, and receipt. Engagement state persists across context compression, so long engagements do not lose their place.
+>
+> One beauty of a deliberate product: it is honest about evaluation. The repo documents its benchmark methodology and treats a single agentic run as a noisy sample; it publishes methodology, not a score it cannot stand behind.
+>
+> Install: `hermes profile install https://github.com/Strategic-Automation/violin`. Built for authorized targets only.
+
+**First comment on PH (optional):**
+> I am the maintainer. Happy to answer skeptical questions about the guard, the evidence model, or the evaluation. If you want to try it, the README has a two-command install. It is MIT and built for authorized testing only.
+
+### Curated indexes / awesomes
+
+Status on "awesome"/curated listings: the repo has already been through a large awesome-list PR campaign (42 PRs, 10 merged, 20 still open). Awesome-list submissions are effectively a completed, low-yield channel. **Do not spend new effort here.** If a specific, high-quality curated index genuinely fits and is verifiably unlisted, one PR each is fine, but only as background work, never as the strategy.
+
+Where Violin genuinely fits if not already there: `awesome-pentest`, `awesome-ai-security`, `awesome-llm-agents`, `awesome-cybersecurity-tools`, and any Hermes/agent ecosystem list. Check each for an existing entry before submitting a second time.
+
+---
+
+## 10. Measurement
+
+**What to track each week:**
+
+| Metric | Where | Meaning |
+|---|---|---|
+| Stars/week | `gh api repos/Strategic-Automation/violin` (field `stargazers_count`); record weekly delta | Core interest signal |
+| Referral traffic per channel | GitHub repo traffic: `gh api repos/Strategic-Automation/violin/traffic/popular/referrers` and `clones` | Which channel actually drives visitors and installs |
+| Install count | Your own analytics if the readme/install is behind a redirect you control; otherwise approximate via clone traffic | The real action metric |
+| Issues/PRs from launch | `gh api search/issues -q "repo:Strategic-Automation/violin"` | Engagement depth, not just eyeballs |
+| Docs/badge referrer | `gh api repos/Strategic-Automation/violin/traffic/popular/paths` | Which surfaces convert |
+
+**Decision rule:** give each channel three real attempts with distinct copy (not three reposts of the same line). If a channel produced no referral visitors and no stars after three attempts, stop investing executive time in it and let it be passive SEO. Channels that produced any sign of real interest (comments, a conversion, a slow climb) get a second-week refinement. HN and the native Hermes community are the two channels most likely to earn follow-through; if neither lands, re-open the positioning before spending more on directories.
+
+---
+
+## 11. Reply / engagement templates
+
+**To a PR/merge-request reviewer (or a thoughtful HN/Reddit commentator):**
+> Thanks, this is exactly the review the guard needed. On your point about [X]: the current behavior is [Y] because [reason from the docs]. I have opened issue #N to track tightening it, and I would welcome another pass once it is in. If you use Violin on an authorized lab target, the friction you flagged will be the most valuable signal I get.
+
+**To a skeptic (short, non-defensive):**
+> Fair pushback, and I agree the default state of "AI pentesting" is overclaimed. What I am asking people to judge is the enforcement boundary, not the model: a required guard plus signed receipts, so a finding is verifiable. The repo documents methodology and deliberately publishes no live score. If that specific property is where you take issue, I want the detail.
+
+**To a genuine bug report from launch:**
+> Thank you, this is reproducible and the fix is worth doing properly. To confirm the environment: Violin [version], Hermes [version], OS [platform]. I have logged it as #N with your steps and guard output; a fix lands with a regression test in the next release. If this blocks your authorized lab work, say so and I will prioritize it.
+
+**To "can I use this without authorization?" (must be an unambiguous refusal + lab pointer):**
+> No. Violin is designed for systems you own or have written authorization to test, and the guard enforces scope and approvals by policy. Do not use it against any target without that authorization. For practicing safely, use local by-design targets: a deliberately vulnerable app (the repo ships a practice target definition you can run locally in Docker), a sandboxed lab, or localhost. That is the authorized, legal way to evaluate it.
+
+---
+
+## 12. Compliance guardrails for this kit (and for every post)
+
+Re-read this before every post:
+
+1. **Never post about attacking a system you do not own or lack written authorization to test.** Every demo, screenshot, and claim in this kit assumes a local lab, localhost, or a deliberately vulnerable application you control (run the practice target the repo ships, locally in Docker).
+2. **Never publish client data or engagement evidence.** No real target IPs, no real findings from real engagements, no scope.yaml contents from client work, no screenshots of live target output. Show the tool mechanics with localhost or the Duck Store only.
+3. **Keep example targets to the local lab.** The README itself says the benchmark runs against `http://localhost:<published-port>` and the Duck Store definition ships in-repo. Mirror that in every public example.
+4. **Do not oversell.** The repo documents benchmark methodology and calibration but no live score. Claiming a number that is not in the repo is fabrication, and this kit hard-rules against it.
+5. **Never imply unauthorized use is acceptable or normal.** Every post states authorized-targets-only, and the emphatic refusal canned reply (section 11) is the correct response to any "can I point this at X without permission" question.
+
+---
+
+*End of kit. Before each new platform push, re-verify star count and version from the repo (section 10 references the exact commands) so every post ships accurate numbers.*

--- a/README.md
+++ b/README.md
@@ -105,12 +105,13 @@ tasks are not moved between phase sections.
 
 ## Guard tools
 
-The plugin registers eleven Hermes tools from one typed registry:
+The plugin registers twelve Hermes tools from one typed registry:
 
 | Tool | Purpose |
 |---|---|
 | `violin_record_ptt` | Create, start, refresh, close, or cancel a PTT task |
 | `violin_record_hypothesis` | Create or update a scoped hypothesis |
+| `violin_submit_finding` | Submit a validated finding bound to its signed execution receipts |
 | `violin_exec` | Execute one guarded command |
 | `violin_exec_burst` | Execute a bounded command file |
 | `violin_exec_status` | Read background execution status |

--- a/docs/articles/coverage-discipline-for-agent-assisted-pentests.md
+++ b/docs/articles/coverage-discipline-for-agent-assisted-pentests.md
@@ -1,0 +1,133 @@
+---
+title: Coverage discipline for agent-assisted pentests
+description: Why unchecked coverage is the real failure mode of agent pentesting, and how a disposition matrix makes 'tested and clean' distinguishable from 'never tested'.
+tags:
+  - agentic-security
+  - pentesting
+  - methodology
+  - coverage
+canonical_url: https://github.com/Strategic-Automation/violin
+cover_image_note: Dark technical graphic — a coverage matrix on the left with tested / not_applicable / blocked cells, a scope.yaml obligations list in the centre, and a signed receipt on the right; the three are linked but visibly separate.
+---
+
+# Coverage discipline for agent-assisted pentests
+
+The client readout goes like this. You present four findings — a stored XSS, a missing rate limit on login, an IDOR on the orders endpoint, a default-credential admin account. The client's engineering lead looks at the scope, points at the routes you never mentioned, and asks a question you cannot answer with certainty: "Did you test that, or did you skip it?"
+
+If your answer is "the agent must have got to it," you have already lost. Not because the exploitation was bad — the findings are real — but because you cannot distinguish *tested and clean* from *never tested*. On paper and in a remediation plan those are different statements with different costs. Your report does not say which one happened. That is a coverage failure, and it is the failure mode that actually sinks an agent-assisted engagement.
+
+## Agents make this worse, not better
+
+A capable agent is the worst possible candidate for silently skipping work, because it is confident, it is fast, and it never tells you what it left out. It will drive straight at a juicy injection, validate it, and file a finding. The forty smaller obligations it spectated instead — the open redirect on the SSO flow, the coupon-state abuse, the admin route it decided was out of scope — simply never resurface. There is no system push-back, because nothing in the loop knows they were owed.
+
+That is the difference between a capability problem and a coverage problem, and it is the distinction most agent tooling never makes. Missing *capability* means the agent did not know how to test something. Missing *coverage* means it did not even engage with it — no probe, no evidence, no recorded decision. A client cannot tell the two apart from a findings list alone. The only correct answer is to make the engagement end with every in-scope route and every required testing category carrying an explicit disposition: a finding, evidence of the attempt, or a written reason for exclusion.
+
+## What disposition discipline looks like mechanically
+
+In Violin those obligations and dispositions are real, enforced files, not a prompt politely asking the agent to be thorough.
+
+**Obligations come from scope.** The scope document (`scope/scope.yaml`) carries an `engagement.coverage_obligations` list — the client-provided, in-scope routes and methods the engagement owes. These are the contractual minimums. The coverage matrix must map every one of them.
+
+**The coverage matrix is a flat file, not prose.** `state/coverage-matrix.yaml` holds one cell per route, method, parameter boundary, auth flow, and relevant vuln class. Every cell has exactly two fields, and the status field is a closed set:
+
+```yaml
+coverage:
+  'post /api/v1/auth/login':
+    status: tested
+    evidence_or_reason: 'evidence/vuln-research/login.txt — 401 w/o creds, 200 w/ creds'
+  'rate_limits on /api/v1/auth/login':
+    status: tested
+    evidence_or_reason: 'H-007; evidence/vuln-research/no_rate_limit_burst.txt — no 429 after 10 attempts'
+  'admin_route':
+    status: blocked
+    evidence_or_reason: 'blocked by scope guard: /admin not in scope.yaml'
+```
+
+Three dispositions exist — `tested`, `not_applicable`, `blocked` — and each carries a proof requirement enforced by the close gate:
+
+- **`tested`** must cite an artifact: an `evidence/` path or a hypothesis id. A bare narrative ("no open redirect parameter found") is aspirational coverage, not proof, and fails the gate.
+- **`not_applicable`** must cite an `evidence/` file *showing the probe*. "No rate-limit behaviour observed" with no saved output is memory reconstruction — the exact false-positive factory — and fails. Run the probe, save its output under `evidence/vuln-research/`, then reference that path.
+- **`blocked`** must name the guard that prevented testing. You cannot silently drop a route; you have to say which boundary stopped you.
+
+The methodology is a second, coarser dimension: `state/methodology-gates.yaml` dispositions each of the ten WSTG category gates against that same three-state schema — information-gathering, configuration-deployment, authentication-session, authorization, input-validation, error-handling, cryptography, business-logic, client-side, api-testing. Where a full matrix cell answers "was this route touched," a methodology gate answers "was this *category* of testing even considered."
+
+**Closeout is a gate, not a habit.** Closing the vulnerability-research phase means marking the PTT task `[x]` via `violin_record_ptt`. When audit mode is on, that transition validates the whole structure before it allows the phase to close: the matrix must exist, every `coverage_obligations` entry must map to a cell keyed by its exact lowercased string, every methodology gate must be dispositioned, no hypothesis may be left unresolved in *Candidate* or *Likely*, and rejections that never ran their cheapest discriminating test are called out by name. The guard fails loudly:
+
+```
+VULN_RESEARCH cannot close — fix ALL of the following:
+  - undispositioned coverage:  post /api/v1/auth/login (no coverage-matrix cell)
+  - undispositioned methodology gates:  cryptography
+  - rejections that never ran their cheapest discriminating test:  H-043
+```
+
+The negative-recording rule matters most here, and it is explicit in the repo's coverage-closeout guidance: **silence is not coverage.** A class that was probed and saved no evidence is a `not_applicable` row only when the evidence file proves the probe ran. A missing rate limit you did actually demonstrate — a bounded burst with no 429, lockout, or CAPTCHA — is not a `not_applicable` note; it is a *finding*, submitted through the normal finding path with the probe evidence.
+
+## Coverage and vulnerability credit must never mix
+
+Here is the rule that keeps the whole system honest, and it is stated plainly in the project's methodology: hypotheses remain a work-planning aid, and coverage and methodology files remain closeout controls. **Neither is ever joined to a finding for vulnerability credit.**
+
+The client-report reason this matters is that a coverage ledger and a findings store answer different questions, and conflating them corrupts both. If ticking a coverage checkbox could manufacture a finding, you would be tempted to inflate a report with "tested" rows — and an auditor could never trust a clean coverage section as anything but padding. If, inversely, a finding's existence could satisfy a coverage obligation, the agent would be free to stop the moment it found something juicy, and the four-finding report would quietly never mention the forty routes. The separation works in both directions: a finding is only real when it is bound to a signed execution receipt, and coverage is only complete when every obligation ends with a dispositioned cell. Completing one does nothing to the other. The metric that matters — in the codebase's own three independent dimensions — is the finding score, the coverage disposition, and the methodology disposition, kept apart on purpose.
+
+That separation is what makes the client answer possible. When the engineering lead asks about the SSO redirect, you do not say "trust me." You open the matrix, find the cell, and show the disposition: `tested`, citing `evidence/vuln-research/redirect-probe.txt`. Or `blocked`, naming the guard. Or — and this is the real product of the discipline — you find *no cell*, which is exactly the honest thing to discover before the meeting, not during it.
+
+## A worked example
+
+Scope declares the login route owed and audit mode is on. `scope.yaml`:
+
+```yaml
+engagement:
+  audit_mode: true
+  require_methodology_gates: true
+  coverage_obligations:
+    - "POST /api/v1/auth/login"
+    - "GET /api/v1/orders"
+```
+
+You probe rate limiting as a single guarded burst — one `violin_exec` call, not ten, because execution is sync-credit budgeted and you want one signed receipt carrying the full sequence:
+
+```
+violin_exec(eng_dir=..., phase="VULN_RESEARCH",
+  command="for attempt in $(seq 1 10); do \
+    curl -s -o /dev/null -w \"rapid attempt $attempt: %{http_code}\n\" \
+      -X POST \"$TARGET/api/v1/auth/login\" \
+      -H 'Content-Type: application/json' \
+      -d '{\"email\":\"a@b.c\",\"password\":\"wrong\"}'; \
+  done | tee $ENG_DIR/evidence/vuln-research/no_rate_limit_burst.txt")
+```
+
+The loop shows `200` ten times, zero `429`, zero lockout. That absence is a finding, not a coverage note, so you submit it: `violin_submit_finding` citing the burst's receipt. Decisive proof is the full response sequence in the saved file, plus an explicit "no 429 after N consecutive attempts" summary line — not a bare status tail.
+
+Then the cells land in the matrix, with the obligation's exact lowercased string `post /api/v1/auth/login` present in the cell key, and the methodology gate dispositions the auth category by citing the same probe file. When the whole phase is marked done, the close gate runs: every obligation maps, every category is dispositioned, every hypothesis is either validated or rejected with its test actually run. The phase closes, and the readout is defence-ready.
+
+## Honest limits
+
+A disposition matrix is a control, not a verdict. Three things it does not do.
+
+**It does not prove quality.** The gate validates that a `tested` cell cites an artifact and a `blocked` cell names a guard. It cannot tell you whether the cited probe was a good probe or a twenty-second glance. An agent can honestly disposition a matrix full of shallow tests. The discipline raises the cost of *silent* skips to near zero; it does not by itself raise the quality of the attempts. That is still the human's job — and Violin is supervised by design, with the operator owning scope, approvals, and the final report.
+
+**A single run is a noisy sample.** This is the project's own doctrine: agentic runs swing several points run-to-run even at temperature zero, so one run — of anything — is not a measure of reliable capability. Apply the same skepticism to a single engagement's coverage. The matrix is your per-engagement ledger; treat an engagement that closes with thin cells as a signal, not a prediction about the next one.
+
+**The ledger is only as honest as the human who lets it.** Nothing stops an operator from writing a false `blocked` reason or a shallow `tested` reference. The guard catches structure and reference integrity; it cannot stop a determined human from lying in a text field. That is not a tool failure. It is why the signed-execution-receipt layer matters: the finding side of the ledger is tamper-evident, and the coverage side is only as strong as the report owner who stands behind it. Both still answer to a human.
+
+## The shorter version
+
+The failure of an agent-assisted test is almost never that it lacked a technique. It is that the engagement ended without you being able to say, route by route and category by category, what was tested, what was genuinely absent, and what was excluded and why. A coverage matrix with three dispositions, derived from the scope obligations and enforced at phase closeout, converts that unknowable into a defensible answer. And it keeps that answer strictly separate from vulnerability credit, so you cannot talk yourself — or a client — into a padded report.
+
+Violin is an open-source, MIT-licensed Hermes-native profile that builds this in: obligations from `scope.yaml`, a coverage matrix and methodology gates validated before the research phase can close, and findings bound only to signed receipts.
+
+```bash
+hermes profile install https://github.com/Strategic-Automation/violin
+hermes -p violin
+```
+
+If you cover this territory professionally — scope negotiation, WSTG category design, closeout practice, what makes a decisive probe — the playbooks and gate surface are the right places to contribute. The coverage problem is not theorised here; it is encoded, enforced, and worth hardening.
+
+https://github.com/Strategic-Automation/violin
+
+<!-- PROMO
+Social (X / LinkedIn): The real failure mode of agent-assisted pentesting is never a missing technique — it is unchecked coverage: an agent that finds three good bugs and silently skips forty owed tests, leaving you unable to tell a client 'tested and clean' from 'never tested'. This article shows a disposition matrix derived from scope obligations, with three enforced states, that stays strictly separate from vulnerability credit.
+Reddit r/netsec / r/cybersecurity title candidates:
+- Your agent found three bugs and skipped forty tests — and you can't tell the difference
+- "Tested and clean" vs "never tested": the coverage problem in agent-assisted pentests
+- The pentest lever agents can't fake: dispositioning every in-scope obligation, not just counting findings
+-->

--- a/docs/articles/guardrails-for-agentic-pentesting.md
+++ b/docs/articles/guardrails-for-agentic-pentesting.md
@@ -1,0 +1,166 @@
+---
+title: Guardrails for agentic pentesting
+description: An open-source, Hermes-native agentic pentest profile with a required execution guard, receipt-backed findings, and honest benchmark accounting.
+tags:
+  - agentic-security
+  - pentesting
+  - llm-agents
+  - security-tools
+canonical_url: https://github.com/Strategic-Automation/violin
+cover_image_note: Dark technical cover graphic — a terminal on the left, a signed JSON execution receipt on the right, a clear scope boundary drawn between them.
+---
+
+# Guardrails for agentic pentesting
+
+The finding was perfect. The client still said no.
+
+The SQL injection was real — a textbook critical, with severity scored, impact explained, remediation drafted, and a clean Markdown write-up attached. By every visible measure it was a good finding. And it was worthless, because at the validation call nobody could produce the raw request and response that produced it. The agent had the bytes once. Then context got compacted, the session rolled on, and the exact exchange was gone. What remained was prose about a vulnerability, with nothing authoritative underneath.
+
+That is the failure mode no demo shows. Agentic pentest tooling can absolutely find real bugs. The hard problem is everything that comes after the exploit fires: proving the finding, keeping the agent inside scope, and surviving a long engagement without the model forgetting what it already did. This article is about Violin, an open-source profile that treats those problems as the actual product.
+
+## Demo-ing well is not the same as being trustworthy
+
+The demo pipeline is seductive. Point an agent at a deliberately vulnerable lab, watch it enumerate, find an injection, and pop a flag, all in a single uninterrupted run of a few hundred tokens of tool calls. It looks done. It is not done.
+
+Three things a successful demo does not show you:
+
+- **Whether the agent stays inside scope when the engagement runs for ten hours and forty screens of context.** Labs are forgiving. Production isn't.
+- **Whether a finding can be defended to a client.** A client wants the authenticated request and the response bytes, matched to the exact thing the agent claims. Screenshots and recollections don't hold up in a remediation meeting.
+- **Whether the state survives when the model's context window gets summarised.** Mid-engagement you will hit the prompt-token limit. An agent that forgets its own active task, hypotheses, and collected evidence is not an agent you can brief.
+
+Violin's contribution is not a better model or a bigger tool chest. It is a discipline layer placed at the boundaries where autonomous agents lie: the target-execution boundary and the finding-submission boundary. The pitch is simple: an agent can only touch targets through a required guard, and it can only record findings that are bound to signed execution receipts.
+
+## A hard guard at the target-execution boundary
+
+Violin is a Hermes-native profile. You install it, point it at an authorized target, and it plans the engagement against an approved scope. From then on, nothing touches a target without passing through the guard.
+
+```bash
+hermes profile install https://github.com/Strategic-Automation/violin
+hermes -p violin
+```
+
+The guard is a Hermes plugin that registers one typed registry of tools. Target commands go through `violin_exec` (single commands) or `violin_exec_burst` (bounded batches). Before it runs a single byte against a target, the guard checks:
+
+- **Scope.** The command's targets — resolved from IP, CIDR, domain, URL, and role literals, including inside pipelines and subshells — must sit inside `scope.yaml`. Out-of-scope and forbidden-action conflicts hard-block.
+- **Phase and active PTT task.** Work is organised as a PTT (plan-task-thing) board. A command under `RECON` is refused if the active task is filed under `EXPLOITATION`.
+- **Skill and hypothesis binding.** The active task must be bound to a delivered, routed skill, and hypotheses must be fresh, not stale evidence-that-was-already-used.
+- **History.** Exact-repeat commands and duplicate detection keep the agent from re-running work it already did and forgot.
+- **Synchronization.** Credential-and-review accounting means a reviewed batch must be settled before the next window of commands opens.
+- **Destructive patterns.** `rm -rf`, `mkfs`, `dd of=/dev/...`, WAF-and-destructive payload shapes are hard blocks with no bypass.
+
+This is the admission checklist, exposed as a CLI for diagnostics:
+
+```bash
+python $HOME/.hermes/profiles/violin/scripts/violin_guard.py check-command \
+  --scope "$ENG_DIR/scope/scope.yaml" --eng-dir "$ENG_DIR" \
+  --session-id "<session-id>" --phase RECON \
+  --target "example.com" --command "nmap -sV example.com"
+```
+
+| Exit | Meaning |
+|------|---------|
+| 0    | Allowed — the command may run after normal phase approval |
+| 1    | Blocked — rewrite it or re-scope first |
+| 2    | Review required — explicit approval before running |
+
+The design is fail-closed. When the guard cannot classify a phase, target, or tool, the answer is `review`, never an agent's judgment call to proceed.
+
+```text
+violin_exec(eng_dir=..., phase="RECON", command="nmap -sS -sV -sC --top-ports 1000 -T4 -oA $ENG_DIR/evidence/recon/active/nmap-top1000 <target>")
+```
+
+There are no tool-specific adapters or a binary allowlist of "safe" commands. Any installed non-interactive target tool runs only once the engagement gates pass. This is the important part: the trust model is procedural, not a filter of known-bad binaries.
+
+### The raw terminal hook is a safety net, not containment
+
+Be honest about what an agent scaffold actually controls. Violin keeps Hermes's raw `terminal` tool available for host-local work, and it runs a conservative classifier over those calls — it blocks clearly target-touching commands, network-socket paths, target-bearing variables, and shell-indirection tricks. Here is the honest part: that raw-terminal hook is a **best-effort safety net, not network containment**. It cannot stop a determined model from reaching a network. No prompt-level or tool-level guard can, on its own.
+
+So Violin does not pretend otherwise. The README states it plainly: the raw-terminal hook is best-effort, and `terminal` is for host-local preparation and administration only. Real enforcement comes from the typed boundary — every target command carrying the engagement, scope, phase, PTT, hypothesis, history, and evidence arguments the full guard needs. If you want network containment, put the agent in a network sandbox. Violin complements that; it does not substitute for it.
+
+## Findings must be receipt-backed
+
+The sharpest decision in Violin is what counts as evidence. A validated finding is not a directory of Markdown notes. It is a typed submission bound to one or more signed execution receipts — the JSON records the guard seals when a target command completes.
+
+Each execution receipt carries the command, the authenticated request and response, the execution result, and a signature. The integration binds the receipt to the exact evidence bytes it produced: SHA-256 digests of every declared evidence file travel inside the signed record, and the signature is HMAC-SHA-256 or Ed25519. If a byte in the evidence changes after the fact, verification fails.
+
+A receipt is only as useful as the request it captured, so the guard nudges the agent toward decisive proof. Batch probes emit one JSON object per request so an evaluator can correlate responses without parsing terminal prose:
+
+```json
+{"type":"http_observation","method":"POST","url":"https://target/api/login","status":401}
+```
+
+When `violin_submit_finding` is called, the guard verifies every cited receipt and its evidence digests before appending to `evidence/findings.jsonl`. It refuses a receipt that is unsigned, foreign, or has changed evidence. It warns when a finding's proof chain carries no literal HTTP response bytes.
+
+Why does this matter? Because the currency of a pentest is not the write-up — it is the raw authenticated exchange. An unsigned Markdown finding is a claim. A receipt-bound finding is a claim with a tamper-evident trail back to the exact request a client's engineering team can replay. When the client asks "show me the request," you have the bytes, signed.
+
+## State that survives context compression
+
+Long engagements hit the model's context limit. The naive failure is an agent that, post-compaction, doesn't know which task is active, what hypotheses it was testing, or what it already proved. Violin's answer is that engagement state lives on disk, not just in conversation.
+
+```text
+$ENG_DIR/
+├── scope/
+│   └── scope.yaml
+├── state/
+│   ├── ptt.md
+│   ├── history.md
+│   └── checkpoint.json
+├── hypotheses.md
+├── evidence/
+├── reporting/
+└── retrospective/
+```
+
+PTT tasks, hypotheses, command history, checkpoints, and evidence all persist to the engagement directory. After a compression, the agent resumes from these files instead of reconstructing the engagement from memory. There is a two-step skill-delivery dance — the first `violin_record_ptt` call may return `skill_prepared` and ask you to repeat once the skill content is delivered, explicitly so a binding is not faked by a marker file. State is the product of the run, not an afterthought cleaned up at report time.
+
+Evidence rules are equally deliberate: raw evidence lives under `$ENG_DIR/evidence/<phase>/`, and secrets, dumps, and proof output are kept out of `$ENG_DIR/state/`. Disclosed credentials get redacted to a fingerprint rather than written in full.
+
+## Honest limits
+
+An article like this should state what the tool does not do, because the credibility of the whole approach depends on it.
+
+- **It is not network containment.** The raw-terminal hook is best-effort. Scope discipline is a guardrail and an audit trail, not a firewall. Operate it inside a real network boundary.
+- **It does not pick your model or provider.** Configure those in Hermes. Violin inherits the operator's configured models, tools, and credentials and adds none of its own.
+- **A single benchmark run is a noisy sample.** This is Violin's own doctrine, stated in `docs/BENCHMARKS.md`: agentic runs swing several points run-to-run even at temperature 0, so a one-off score is not a capability measure. Report the distribution over at least three runs, and prefer **mean pass@1** — the expected single-run score — over the best run:
+
+```text
+uv run python -m benchmark.aggregate --glob "engagements/benchmark-run-*" \
+  --json-out benchmark/results/aggregate.json \
+  --markdown-out benchmark/results/aggregate.md
+```
+
+  The aggregator reports mean pass@1, its variance, an optimistic pass@k, and a pessimistic pass^k floor — so you know not just what the agent *can* do, but what it *reliably* does.
+
+- **Agent output still needs human validation.** Violin is supervised by design. Operators are responsible for scope, approvals, target ownership, data handling, and local law. A machine that produces signed, scoped, evidence-backed findings still answers to a human who owns the engagement.
+
+## Try it in five minutes
+
+1. **Install and scope.** Run the one-line install, then start with an authorized target. Violin collects the scope into `scope/scope.yaml` — targets, exclusions, rules of engagement, and the authorizing party — and gets written approval before any target interaction. No scope, no testing.
+2. **Open a PTT task.** `violin_record_ptt` creates and activates a task in the right phase and binds its routed skill.
+3. **Run a guarded command.** `violin_exec` for a single command, `violin_exec_burst` for a bounded batch. The guard checks scope, phase, task, hypothesis, and history, then issues a signed execution receipt.
+4. **Submit a receipt-backed finding.** `violin_submit_finding` verifies the cited receipts and their evidence digests, then appends the validated finding to `evidence/findings.jsonl`. Reports render from that canonical store — never from free prose.
+
+That is the whole loop. Scope gates everything; execution is guarded and signed; findings are bound to proof; state survives.
+
+## Where it goes from here
+
+Violin is MIT-licensed, open source from a real maintainer organisation — not a demo reel. The two genuinely valuable ways to contribute are also the two hardest parts to get right:
+
+- **Playbooks.** The routed methodology — web, identity, API, business-logic, LLM-security, misconfig — is a place to encode real-world testing knowledge. New class playbooks should map OWASP/CWE, specify safe PoC techniques, define evidence paths, and list stop conditions and blocked actions.
+- **Guard hardening.** The gate surface is the crown jewel. Find a way a command slips past scope or a security boundary — that is a bug in the trust model, and it is worth fixing well.
+
+If you want a pentest agent you can actually brief to a client — one whose findings carry receipts, whose scope is enforced, and whose benchmarks are reported honestly — look at the repo. The trust problems are the interesting ones.
+
+https://github.com/Strategic-Automation/violin
+
+<!-- PROMO
+Social (X / LinkedIn): Violin is an open-source, Hermes-native agentic pentest profile that puts a required execution guard at the target boundary and binds every finding to a signed execution receipt. It is honest about its limits — no network containment, no model picking, and multi-run benchmark accounting that reports mean pass@1 instead of cherry-picked best runs.
+
+HN title candidates:
+- Agentic pentesting runs on an execution guard and signed receipts
+- Violin: an open-source supervised agentic pentest profile
+- I put a hard guard between an LLM and its pentest target
+- Receipt-backed findings and enforcement for autonomous pentest agents
+- What agentic pentest tooling forgets to demo: proof and scope
+- Violin: a Hermes-native agentic pentester with a fail-closed target guard
+-->

--- a/docs/articles/how-to-evaluate-an-agentic-pentest-tool.md
+++ b/docs/articles/how-to-evaluate-an-agentic-pentest-tool.md
@@ -1,0 +1,91 @@
+---
+title: How to evaluate an agentic pentest tool
+description: Agentic pentesting is demo-rich and evidence-poor. A buyer's checklist for the accountability layer before an agent touches a client network.
+tags:
+  - agentic-security
+  - pentesting
+  - llm-agents
+  - security-evaluation
+canonical_url: https://github.com/Strategic-Automation/violin
+cover_image_note: Dark technical graphic — a checklist card on the left, a signed JSON execution receipt on the right, and a scope boundary line closing a gap in between. No flags, no trophies.
+---
+
+# How to evaluate an agentic pentest tool
+
+An agent found a real critical during the pilot. During the debrief the client's network lead asked for the request and response that produced it. The tool couldn't produce them, because nothing about that run had been recorded in a form that could be replayed. The same week, a second pilot classed it differently: the agent enumerated an internal host that was not in the approved scope. That was an incident, not a finding. Nobody could reconstruct which command touched it, when, or on whose authority.
+
+All three failure modes — an unapproved host, an unlogged command, an unreproducible finding — are the expected output of a certain class of demo. An agent that finds a bug on a lab target is showing model capability. Nothing in that demo promised the tool could do the part that client-facing work actually depends on: prove what it ran, show it stayed inside an approved boundary, and let a human replay the decisive exchange a quarter later.
+
+The agentic-pentest space is demo-rich and evidence-poor. For the person deciding whether one of these tools may ever touch a client network, this separates the two engineering problems involved, walks through the specific controls that make an agent's actions answerable, and ends with a short checklist you can apply to any tool on the market, including the one this repository ships.
+
+## Capability versus accountability
+
+There are two distinct engineering problems in an agentic pentest tool, and they are rarely worked at the same weight.
+
+The first is **capability**: can the model, given a scope and a prompt, enumerate an app, find a bug, and exploit it? This is the problem everyone demos. It is a property of the model and improves when vendors swap in a stronger model or add a playbook. It is why the demo is convincing.
+
+The second is **accountability**: whatever the agent does, can you answer five questions about it? Who authorised it? What exactly did it run, against what? Did it stay inside the approved scope and phase? Can the finding be reproduced next quarter from recorded evidence? What happens when the agent is wrong — a given, eventually?
+
+Production time goes overwhelmingly to the second problem. Capability is a model upgrade away; accountability is a harness you have to design, enforce, and defend to a client or an incident reviewer. When a tool is described only by the first problem — how many bugs it found in a weekend — that tells you nothing about whether it is safe to point at a real network. The scarce engineering is the layer that makes the agent answerable. That layer is what this project, Violin, actually builds.
+
+## The accountability controls, concretely
+
+Violin is a Hermes-native profile, installable in one line: `hermes profile install https://github.com/Strategic-Automation/violin`. Everything below refers to the actual files, tools, and fields in that repository.
+
+**A single guarded execution boundary.** Target commands run only through two typed tools, `violin_exec` (one command) and `violin_exec_burst` (a bounded command file). There are no per-tool execution adapters and no binary allowlist: any installed non-interactive tool may run, but only after the engagement gates pass. The trust model is procedural, not a filter of known-good commands — the only honest version, because an allowlist is always incomplete.
+
+**Fail-closed gates.** Before a command runs, `check_command` (in `plugins/violin_guard/gates/command.py`) orchestrates scope checks, bootstrap completeness, phase and PTT-task validation, skill binding, hypothesis freshness, history de-duplication, sync-credit accounting, and a heartbeat gate. The decisive design rule is what happens on ambiguity: an unclassifiable phase, target, or classification resolves to **review**, never to an agent's judgment to proceed. A guard that lets the model talk its way past an edge case is a liability, not a feature. Destructive, disruptive, credential-dropping, persistence, stealth, and third-party payloads are hard-blocked.
+
+**Scope is an enforced input, not a prompt instruction.** The scope lives in `scope/scope.yaml`, which must name an approving party (`authorized_parties`) and an explicit `authorisation.confirmed: true` before any target interaction. The guard validates required sections (`targets`, `rules_of_engagement`, `engagement`) and enforces that runtime execution uses that canonical file — a different scope file cannot be substituted at execution time. Target literals are resolved from IP, CIDR, domain, hostname, URL, and role fields and are checked even inside pipelines and subshells, so a target cannot hide in a compound command. No scope, no testing.
+
+**Signed receipts bound to findings.** When a target command completes, the guard seals an execution receipt. `receipt_integrity.py` signs the canonical record with an HMAC-SHA-256 or Ed25519 key (the `receipt_hmac_sha256` / `receipt_ed25519` fields) and embeds SHA-256 digests of every declared evidence file (`evidence_sha256`) inside the signed record. Verification is fail-closed: a receipt that is unsigned, foreign, has changed evidence, or points at a symlink returns nothing. A finding cannot be recorded against a receipt that fails that check. Findings are appended to `evidence/findings.jsonl` as typed records — `FIND-NNN` identifiers carrying title, severity, `receipt_paths`, `evidence_paths`, and `execution_ids` — and cited evidence files must themselves be authenticated by a cited receipt. Reports render from that canonical store, not from free prose.
+
+**Explicit statements of what the guard does not cover.** The credibility of a safety layer depends on its stated boundary. Violin documents the raw-terminal hook as a best-effort safety net, not network containment; network isolation is the operator's job. It does not select a model or provider. A receipt proves a command ran and its evidence is intact; it does not by itself judge whether the finding is semantically correct — that remains a human judgment.
+
+**Distribution reporting instead of best-run bragging.** `docs/BENCHMARKS.md` states the methodology doctrine plainly: a single agentic run is a noisy sample, a one-off score is not a capability measure, a repository test pass or calibration run is not a live benchmark score, and capability should be reported as a distribution over at least three runs with **mean pass@1** — not the best run — as the headline, alongside variance and a pessimistic `pass^k` reliability floor.
+
+## What the limits are, plainly
+
+Let me be exact about what this tool does and does not guarantee, so nobody is surprised mid-engagement.
+
+- **It is not network containment.** Scope discipline and the receipt trail exist so that violations are visible and answerable. They are not a firewall. Operate the agent inside a real network boundary and treat the guard as what it is: an audit and enforcement layer, not a sandbox.
+- **Receipts authenticate; they do not vindicate.** A signed receipt proves the command ran, the evidence bytes are unchanged, and the finding cites a real recorded exchange. It does not prove the finding is exploitable in production, does not prove an absence of vulnerabilities, and does not replace the human read on impact. It turns a claim into a replayable trail.
+- **Human judgment is mandatory and is not a fallback — it is the design.** The scope names an approving party. The rules of engagement come from a signed file. The final report is generated from validated findings but its executive summary is placeholder prose a human writes. Violin is supervised by design: write the authorization, own the target, review the batches. That is what makes the other properties safe to rely on.
+- **Benchmarks are signals about a distribution, not proof of a perfect score.** Any vendor quoting a single best run is telling you about an upper bound, which is the least useful number. Ask for mean, variance, and what is reliably reproducible run-to-run.
+
+This is the honest framing, and it is the only framing that survives a client or an incident reviewer actually looking.
+
+## An evaluation checklist you can apply to any tool
+
+Use these questions as a filter. A credible answer is specific and names mechanics; a weak answer is a demo video or a logo wall.
+
+1. **Is there a single enforced boundary, or can the agent reach the target through a permissive path?** If a general-purpose shell or HTTP tool can touch target hosts without passing the guard, the guard is decorative. Ask: is every target byte forced through one typed boundary? (Violin: yes — `violin_exec` / `violin_exec_burst`; the raw-terminal hook is documented as best-effort and not containment.)
+2. **What is captured, and can it be replayed?** Ask for the authenticated request and response bytes behind a sample finding — not a screenshot, not a prose summary. If the tool can't produce the raw exchange, a remediation call will fail exactly the way the scripted debriefs do.
+3. **Is a finding tamper-evidently linked to its evidence?** Is there a signature over the command and the evidence digests, so that a changed byte is detectable after the fact? (Violin: `evidence_sha256` digests inside the signed receipt; verification fails closed.)
+4. **Fail-open or fail-closed?** What happens when the guard cannot classify the command? If the answer involves the model's judgment, walk away. Fail-closed means ambiguity is a hard stop for review.
+5. **Is scope a signed input or a prompt?** Is scope parsed from the same file the authorizing party approved, and can a target hide inside a pipeline or subshell? Scope as a text instruction is not scope.
+6. **Does the documentation state what it does not stop?** An honest tool tells you where enforcement ends — network containment, model selection, third-party tools. A tool that only lists what it blocks has not earned your trust.
+7. **How are benchmarks reported?** Distribution over multiple runs with mean pass@1 as the headline, or one cherry-picked best run? Is a test-suite pass presented as a real score?
+8. **Who signs off?** Is there a named, confirmed authorizing party and a human approval point in the workflow, or does the tool assume its own clearance? (Violin: `authorized_parties` and `authorisation.confirmed` in `scope.yaml`.)
+
+## The honest pitch
+
+The agentic-pentest market will keep shipping demos. The tools that survive client work will be the ones built around accountability: one guarded boundary, fail-closed gates, signed receipts bound to reproducible findings, an explicit statement of what the guard does not cover, and benchmark reporting that a statistician would not laugh at. That is the design this repository commits to — a claim you can verify by reading the code, not by watching a highlight reel.
+
+Install it and evaluate it with the checklist above:
+
+```bash
+hermes profile install https://github.com/Strategic-Automation/violin
+hermes -p violin
+```
+
+Violin is MIT-licensed and built for authorized engagements only — you own the scope, the approvals, and the law. If you think a control is wrong, the design is arguable and the discussions are open; the trust model is exactly the part worth arguing about.
+
+<!-- PROMO
+Social (X / LinkedIn): Agentic pentesting is demo-rich and evidence-poor. Before you point an agent at a client network, evaluate the accountability layer — one enforced execution boundary, fail-closed gates, signed receipts bound to reproducible findings, and distribution-based benchmarks — not the demo reel. This walkthrough of the controls and a short buyer's checklist is based on Violin, an MIT-licensed, Hermes-native, authorized-only profile: hermes profile install https://github.com/Strategic-Automation/violin
+
+HN title candidates:
+- How to evaluate an agentic pentest tool
+- Agentic pentesting: capability is the easy half, accountability is the job
+- The demo-to-production gap in agentic pentest tooling
+-->

--- a/docs/index.html
+++ b/docs/index.html
@@ -112,6 +112,8 @@
   .cmp th:nth-child(4){color:var(--fg);border-bottom:1px solid var(--red)}
   .cmp td:nth-child(4){background:rgba(255,59,74,.075);color:var(--fg);
     box-shadow:inset 2px 0 0 var(--red)}
+  .cmp td,.cmp th{line-height:1.52}
+  .cmp-wrap th,.cmp-wrap td{border-bottom:1px solid rgba(255,255,255,.085)}
   .scroll-hint{color:var(--muted);font-size:12.5px;margin:8px 0 0}
   .caption{color:var(--muted);font-size:13px;margin:12px 0 0}
   .steps{counter-reset:s;margin:0;padding:0;list-style:none}

--- a/docs/index.html
+++ b/docs/index.html
@@ -3,12 +3,12 @@
 <head>
 <meta charset="utf-8"/>
 <meta name="viewport" content="width=device-width, initial-scale=1"/>
-<title>Violin — supervised agentic pentest profile for Hermes Agent</title>
-<meta name="description" content="Violin is an open-source, supervised agentic penetration-testing profile for Hermes Agent. Scope-gated target execution, signed execution receipts, receipt-backed findings, and engagement state that survives context compression."/>
+<title>Violin — supervised agentic pentesting with signed evidence</title>
+<meta name="description" content="Violin is an open-source agentic pentest profile for Hermes Agent built for authorised engagements: scope-gated command execution, signed execution receipts, coverage you can defend in a client readout, and engagement state that survives compression."/>
 <link rel="canonical" href="https://strategic-automation.github.io/violin/"/>
 <meta property="og:type" content="website"/>
-<meta property="og:title" content="Violin — supervised agentic pentest profile for Hermes Agent"/>
-<meta property="og:description" content="Scope-gated target execution, signed execution receipts, and receipt-backed findings. MIT licensed, installs in one command."/>
+<meta property="og:title" content="Violin — supervised agentic pentesting with signed evidence"/>
+<meta property="og:description" content="Scope-gated target execution, signed execution receipts, WSTG-style coverage disposition. MIT licensed, runs on Kali/Parrot, drives the tools already in your image."/>
 <meta property="og:image" content="https://strategic-automation.github.io/violin/assets/social-preview.png"/>
 <meta name="twitter:card" content="summary_large_image"/>
 <link rel="icon" href="assets/logo.png"/>
@@ -21,14 +21,14 @@
   "operatingSystem": "Linux, macOS, Windows",
   "license": "https://opensource.org/licenses/MIT",
   "url": "https://github.com/Strategic-Automation/violin",
-  "description": "Supervised agentic penetration-testing profile for Hermes Agent with a required execution guard, signed execution receipts, and receipt-backed findings.",
+  "description": "Supervised agentic penetration-testing profile for Hermes Agent: one guarded execution boundary, signed execution receipts, receipt-backed findings, and coverage disposition for authorised engagements.",
   "offers": {"@type": "Offer", "price": "0", "priceCurrency": "USD"}
 }
 </script>
 <style>
   :root{
     --bg:#0a0a0f; --panel:#12121a; --panel2:#171722; --line:#26263a;
-    --fg:#e9e9f0; --muted:#a0a0b0; --red:#ff3b4a; --gold:#ffd166;
+    --fg:#e9e9f0; --muted:#a0a0b0; --red:#ff3b4a; --gold:#ffd166; --green:#3fb950;
     --mono:ui-monospace,SFMono-Regular,"SF Mono",Menlo,Consolas,monospace;
   }
   *{box-sizing:border-box}
@@ -38,45 +38,35 @@
     -webkit-font-smoothing:antialiased}
   a{color:var(--gold);text-decoration:none}
   a:hover{text-decoration:underline}
-  .wrap{max-width:1060px;margin:0 auto;padding:0 24px}
-  header.top{border-bottom:1px solid var(--line);position:sticky;top:0;background:rgba(10,10,15,.92);backdrop-filter:blur(8px);z-index:9}
+  .wrap{max-width:1080px;margin:0 auto;padding:0 24px}
+  header.top{border-bottom:1px solid var(--line);position:sticky;top:0;background:rgba(10,10,15,.93);backdrop-filter:blur(8px);z-index:9}
   header.top .wrap{display:flex;align-items:center;gap:14px;height:64px}
   header.top img{width:30px;height:30px;border-radius:6px}
   header.top b{letter-spacing:.14em;text-transform:uppercase;font-size:13px}
-  header.top nav{margin-left:auto;display:flex;gap:20px;font-size:14px}
+  header.top nav{margin-left:auto;display:flex;gap:19px;font-size:14px}
   header.top nav a{color:var(--muted)}
   header.top nav a:hover{color:var(--fg);text-decoration:none}
-  .hero{padding:60px 0 44px;position:relative;overflow:hidden}
+  .hero{padding:58px 0 42px;position:relative;overflow:hidden}
   .hero::before{content:"";position:absolute;left:-14%;top:-190px;width:900px;height:520px;
     background:radial-gradient(closest-side,rgba(255,59,74,.16),transparent 72%);pointer-events:none}
   .hero .wrap{position:relative}
   .hero-cols{display:grid;grid-template-columns:minmax(0,1fr) 356px;gap:52px;align-items:start}
-  h1{font-size:50px;line-height:1.1;margin:0 0 16px;letter-spacing:-.025em;max-width:20ch;text-wrap:balance}
+  .kicker{font:600 12.5px/1 var(--mono);letter-spacing:.12em;text-transform:uppercase;color:var(--gold);
+    margin:0 0 14px}
+  h1{font-size:49px;line-height:1.1;margin:0 0 16px;letter-spacing:-.025em;max-width:21ch;text-wrap:balance}
   h1 .accent{color:var(--red)}
-  .lede{font-size:19px;color:var(--muted);margin:0 0 22px;max-width:62ch}
+  .lede{font-size:18.5px;color:var(--muted);margin:0 0 22px;max-width:63ch}
   .install{display:flex;align-items:flex-start;gap:12px;background:var(--panel);border:1px solid var(--line);
     border-radius:10px;padding:13px 15px;font-family:var(--mono);font-size:13.5px;overflow:auto}
   .install code{color:var(--gold);white-space:pre-wrap;word-break:break-word;line-height:1.55}
   .install button{margin-left:auto;background:transparent;color:var(--fg);border:1px solid var(--line);
     border-radius:999px;padding:6px 15px;font:inherit;font-size:13px;font-weight:600;cursor:pointer;
     white-space:nowrap;flex:0 0 auto}
-  .install button:hover{border-color:var(--red);color:var(--fg)}
+  .install button:hover{border-color:var(--red)}
+  .install .prompt{color:var(--muted);user-select:none}
   .meta-line{margin:14px 0 0;font-size:13.5px;color:#bcbcc9}
   .meta-line span{white-space:nowrap}
   .meta-line .dot{margin:0 8px;color:var(--line)}
-  .gate-panel{background:var(--panel);border:1px solid var(--line);border-radius:14px;padding:20px 22px;
-    margin-top:5px}
-  .gate-panel h3{margin:0 0 4px;font-size:12.5px;letter-spacing:.1em;text-transform:uppercase;color:var(--red)}
-  .gate-panel p.gp-sub{margin:0 0 14px;font-size:13.5px;color:var(--muted)}
-  .gate-panel ol{margin:0;padding:0;list-style:none;counter-reset:g}
-  .gate-panel li{counter-increment:g;display:flex;gap:10px;align-items:baseline;font-size:14px;
-    padding:6px 0;border-bottom:1px solid var(--line)}
-  .gate-panel li:last-child{border-bottom:0}
-  .gate-panel li::before{content:counter(g);color:var(--gold);font-family:var(--mono);font-size:12.5px;
-    min-width:14px}
-  .gate-panel .gp-foot{margin-top:14px;font-size:13px;color:var(--muted);border-left:2px solid var(--gold);
-    padding-left:11px}
-  .badges{margin-top:16px;display:flex;flex-wrap:wrap;gap:8px;align-items:center}
   .links{margin-top:18px;display:flex;flex-wrap:wrap;gap:10px;align-items:center}
   .chip{display:inline-block;border:1px solid var(--line);background:transparent;color:var(--muted);
     border-radius:999px;padding:6px 13px;font-size:13px}
@@ -84,41 +74,81 @@
   .btn-primary{display:inline-block;background:#d92b3a;color:#fff;border-radius:999px;
     padding:9px 18px;font-size:13.5px;font-weight:600}
   .btn-primary:hover{filter:brightness(1.1);text-decoration:none}
-  .install .prompt{color:var(--muted);user-select:none}
-  section{padding:56px 0;border-top:1px solid var(--line)}
+  .gate-panel{background:var(--panel);border:1px solid var(--line);border-radius:14px;padding:20px 22px;margin-top:5px}
+  .gate-panel h3{margin:0 0 4px;font-size:12.5px;letter-spacing:.1em;text-transform:uppercase;color:var(--red)}
+  .gate-panel p.gp-sub{margin:0 0 14px;font-size:13.5px;color:var(--muted)}
+  .gate-panel ol{margin:0;padding:0;list-style:none;counter-reset:g}
+  .gate-panel li{counter-increment:g;display:flex;gap:10px;align-items:baseline;font-size:14px;
+    padding:6px 0;border-bottom:1px solid var(--line)}
+  .gate-panel li:last-child{border-bottom:0}
+  .gate-panel li::before{content:counter(g);color:var(--gold);font-family:var(--mono);font-size:12.5px;min-width:14px}
+  .gate-panel .gp-foot{margin-top:14px;font-size:13px;color:var(--muted);border-left:2px solid var(--gold);padding-left:11px}
+  section{padding:54px 0;border-top:1px solid var(--line)}
   h2{font-size:27px;margin:0 0 8px;letter-spacing:-.01em}
-  .sub{color:var(--muted);margin:0 0 28px;max-width:78ch}
-  .cards{display:grid;grid-template-columns:repeat(auto-fit,minmax(272px,1fr));gap:16px}
+  .sub{color:var(--muted);margin:0 0 28px;max-width:80ch}
+  .cards{display:grid;grid-template-columns:repeat(auto-fit,minmax(280px,1fr));gap:16px}
   .card{background:var(--panel);border:1px solid var(--line);border-radius:12px;padding:20px}
   .card h3{margin:0 0 8px;font-size:16px}
   .card h3::before{content:"▸ ";color:var(--red)}
   .card p{margin:0;color:var(--muted);font-size:14.5px}
-  .flow{display:flex;flex-wrap:wrap;align-items:center;gap:10px;margin:10px 0 26px}
-  .step{background:var(--panel2);border:1px solid var(--line);border-radius:9px;padding:10px 14px;font-size:14px}
-  .step b{display:block;font-size:11.5px;letter-spacing:.1em;text-transform:uppercase;color:var(--red)}
-  .arrow{color:var(--muted)}
+  .cols2{display:grid;grid-template-columns:1fr 1fr;gap:16px}
+  .yes,.no{background:var(--panel);border:1px solid var(--line);border-radius:12px;padding:18px 20px}
+  .yes h3,.no h3{margin:0 0 10px;font-size:14px;letter-spacing:.08em;text-transform:uppercase}
+  .yes h3{color:var(--green)}.no h3{color:var(--red)}
+  .yes ul,.no ul{margin:0;padding-left:18px;color:var(--muted);font-size:14.5px}
+  .yes li,.no li{margin:5px 0}
   table{width:100%;border-collapse:collapse;font-size:14.5px}
-  th,td{text-align:left;padding:9px 12px;border-bottom:1px solid var(--line);vertical-align:top}
+  th,td{text-align:left;padding:10px 12px;border-bottom:1px solid var(--line);vertical-align:top}
   th{color:var(--muted);font-size:12px;letter-spacing:.09em;text-transform:uppercase}
   td code{font-family:var(--mono);color:var(--gold);font-size:13.5px}
-  .grid{display:grid;grid-template-columns:repeat(auto-fit,minmax(230px,1fr));gap:14px}
+  .cmp th:nth-child(1){width:23%}
+  .cmp td:nth-child(2),.cmp th:nth-child(2){color:var(--muted)}
+  .cmp td:nth-child(3),.cmp th:nth-child(3){color:var(--muted)}
+  .cmp td:nth-child(4),.cmp th:nth-child(4){background:rgba(255,59,74,.05)}
+  .cmp-wrap{overflow-x:auto;border:1px solid var(--line);border-radius:12px}
+  .cmp-wrap table{min-width:768px}
+  .cmp-wrap th,.cmp-wrap td{padding:11px 14px}
+  .cmp tbody tr:nth-child(even),.cmp tr:nth-child(even){background:rgba(255,255,255,.017)}
+  .cmp th:nth-child(4){color:var(--fg);border-bottom:1px solid var(--red)}
+  .cmp td:nth-child(4){background:rgba(255,59,74,.075);color:var(--fg);
+    box-shadow:inset 2px 0 0 var(--red)}
+  .scroll-hint{color:var(--muted);font-size:12.5px;margin:8px 0 0}
+  .caption{color:var(--muted);font-size:13px;margin:12px 0 0}
+  .steps{counter-reset:s;margin:0;padding:0;list-style:none}
+  .steps li{counter-increment:s;position:relative;padding:0 0 20px 46px;border-left:1px solid var(--line);margin-left:12px}
+  .steps li:last-child{border-left-color:transparent}
+  .steps li::before{content:counter(s);position:absolute;left:-13px;top:-2px;width:26px;height:26px;
+    border-radius:50%;background:var(--panel2);border:1px solid var(--line);color:var(--gold);
+    font:600 12.5px/24px var(--mono);text-align:center}
+  .steps b{display:block;margin-bottom:2px}
+  .steps p{margin:0;color:var(--muted);font-size:14.5px}
+  pre{background:var(--panel);border:1px solid var(--line);border-radius:10px;padding:15px 17px;
+    overflow:auto;font-family:var(--mono);font-size:13.5px;color:#dcdce6;margin:12px 0 0}
+  pre .c{color:#8b8b9c}
+  pre .k{color:var(--gold)}
+  pre .ok{color:var(--green)}
+  .grid{display:grid;grid-template-columns:repeat(auto-fit,minmax(232px,1fr));gap:14px}
   .group{background:var(--panel);border:1px solid var(--line);border-radius:12px;padding:16px}
   .group h4{margin:0 0 10px;font-size:12.5px;letter-spacing:.1em;text-transform:uppercase;color:var(--gold)}
-  .group ul{margin:0;padding:0;list-style:none;font-size:14px;color:var(--muted);columns:1}
+  .group ul{margin:0;padding:0;list-style:none;font-size:14px;color:var(--muted)}
   .group li{padding:2px 0}
   .note{background:var(--panel);border:1px solid var(--line);border-left:3px solid var(--gold);
     border-radius:8px;padding:16px 18px;color:var(--muted);font-size:14.5px}
   .note b{color:var(--fg)}
-  pre{background:var(--panel);border:1px solid var(--line);border-radius:10px;padding:15px 17px;
-    overflow:auto;font-family:var(--mono);font-size:13.5px;color:#dcdce6}
+  details{background:var(--panel);border:1px solid var(--line);border-radius:10px;padding:0 16px;margin:0 0 10px}
+  details[open]{padding-bottom:14px}
+  summary{cursor:pointer;padding:14px 0;font-weight:600;font-size:15px;list-style:none}
+  summary::-webkit-details-marker{display:none}
+  summary::before{content:"+ ";color:var(--red);font-family:var(--mono)}
+  details[open] summary::before{content:"– "}
+  details p{margin:0;color:var(--muted);font-size:14.5px}
   footer{border-top:1px solid var(--line);padding:34px 0 56px;color:var(--muted);font-size:14px}
   footer .wrap{display:flex;flex-wrap:wrap;gap:18px;align-items:center}
   footer nav{display:flex;gap:18px;margin-left:auto}
-  @media (max-width:980px){.hero-cols{grid-template-columns:1fr;gap:30px}
-    .gate-panel{max-width:520px}}
+  @media (max-width:980px){.hero-cols{grid-template-columns:1fr;gap:30px}.gate-panel{max-width:520px}
+    .cols2{grid-template-columns:1fr}}
   @media (max-width:720px){h1{font-size:33px}header.top nav{display:none}
-    .install code{white-space:normal;word-break:break-word}
-    .flow{gap:8px}.step{flex:1 1 130px;font-size:13px}}
+    .install code{white-space:normal;word-break:break-word}}
 </style>
 </head>
 <body>
@@ -127,9 +157,11 @@
   <img src="assets/logo.png" alt="Violin logo"/>
   <b>Violin</b>
   <nav>
+    <a href="#for">For pentesters</a>
     <a href="#how">How it works</a>
-    <a href="#tools">Tools</a>
-    <a href="#playbooks">Playbooks</a>
+    <a href="#compare">Compare</a>
+    <a href="#engagement">Engagement</a>
+    <a href="#playbooks">Coverage</a>
     <a href="#limits">Limits</a>
     <a href="#start">Quick start</a>
     <a href="https://github.com/Strategic-Automation/violin/discussions">Discussions</a>
@@ -139,10 +171,12 @@
 
 <div class="hero"><div class="wrap"><div class="hero-cols">
   <div class="hero-copy">
+    <p class="kicker">Open source · MIT · Kali / Parrot · Hermes Agent</p>
     <h1>Supervised agentic pentesting that produces <span class="accent">proof, not prose</span>.</h1>
-    <p class="lede">Violin is an open-source <b>Hermes Agent</b> profile for authorised penetration tests.
-      Every target-touching command passes a required execution guard, every command returns a signed
-      receipt, and every finding must bind to the receipt that proves it.</p>
+    <p class="lede">Violin is built for working testers on authorised engagements. It drives the tools already
+      in your image through a single guarded execution boundary, returns a signed receipt for every command,
+      and refuses a finding that cannot cite one. You keep the engagement state, the coverage disposition,
+      and the final call.</p>
     <div class="install">
       <span class="prompt">$</span>
       <code>hermes profile install \
@@ -151,81 +185,181 @@
     </div>
     <div class="links">
       <a class="btn-primary" href="https://github.com/Strategic-Automation/violin">★ Star on GitHub</a>
-      <a class="chip" href="#start">Quick start</a>
+      <a class="chip" href="#engagement">See an engagement</a>
+      <a class="chip" href="https://github.com/Strategic-Automation/violin/blob/master/docs/BENCHMARKS.md">Benchmark methodology</a>
     </div>
-    <p class="meta-line"><span>MIT licensed</span><span class="dot">·</span><span>v3.2.1</span><span class="dot">·</span><span>Hermes Agent 0.18.0+</span><span class="dot">·</span><span>Kali / Parrot</span></p>
+    <p class="meta-line"><span>MIT licensed</span><span class="dot">·</span><span>v3.2.1</span><span class="dot">·</span><span>Hermes Agent 0.18.0+</span><span class="dot">·</span><span>12 guard tools</span><span class="dot">·</span><span>35 playbooks</span></p>
   </div>
   <aside class="gate-panel">
     <h3>Before a target command runs</h3>
-    <p class="gp-sub">Seven checks, one boundary — <code>violin_exec</code>.</p>
+    <p class="gp-sub">One boundary — <code>violin_exec</code>. Fail closed.</p>
     <ol>
       <li>Written authorisation in <code>scope.yaml</code></li>
-      <li>Approved scope match for the resolved target</li>
+      <li>Approved-scope match for the resolved target</li>
       <li>Active PTT task under the current phase</li>
       <li>Routed specialist skill bound to the task</li>
       <li>Hypothesis binding for the command</li>
       <li>Command history and synchronisation state</li>
-      <li>Engagement gates — fail closed</li>
+      <li>Engagement gates — any failure denies</li>
     </ol>
-    <div class="gp-foot">A passing command returns a signed execution receipt. A finding without one is not a
-      finding.</div>
+    <div class="gp-foot">A passing command returns a signed execution receipt. <code>violin_submit_finding</code>
+      will not accept a finding without one.</div>
   </aside>
 </div></div></div>
 
-<section id="how"><div class="wrap">
-  <h2>The trust problem</h2>
-  <p class="sub">An agent that finds real vulnerabilities is not the hard part any more. The hard part is
-    answering three questions a client, an auditor, or your own team will ask: did it stay in scope, can you
-    prove the finding, and can you resume the engagement tomorrow?</p>
+<section id="for"><div class="wrap">
+  <h2>Built for the way engagements actually run</h2>
+  <p class="sub">Not a demo agent that finds one bug in a deliberately vulnerable app. A harness for scoped,
+    multi-day client work where the report has to survive scrutiny.</p>
   <div class="cards">
-    <div class="card"><h3>Is it in scope?</h3>
-      <p>Scope, phase, active PTT task, routed skill, hypothesis binding, and command history are all checked
-        before a target command is allowed to start. Gates fail closed.</p></div>
-    <div class="card"><h3>Can you prove it?</h3>
-      <p>Each execution returns a signed receipt. A finding is only accepted when it binds to receipts that
-        authenticate the decisive request and response bytes.</p></div>
-    <div class="card"><h3>Can you resume it?</h3>
-      <p>PTT tasks, hypotheses, checkpoints, evidence, and reports live in engagement state on disk, so context
-        compression does not reset the assessment.</p></div>
+    <div class="card"><h3>Scope checked per command</h3>
+      <p>Every target-touching command is resolved against the approved scope before it starts. Out-of-scope
+        hosts are denied, not logged-and-run. Path-scoped URL exclusions are honoured.</p></div>
+    <div class="card"><h3>Your tools, your image</h3>
+      <p>No tool-specific adapters and no target allowlists: installed non-interactive tooling
+        (<code>nmap</code>, <code>nuclei</code>, <code>ffuf</code>, <code>sqlmap</code>, <code>curl</code>)
+        runs through one boundary, so what you learned in the last engagement still applies.</p></div>
+    <div class="card"><h3>Coverage you can defend</h3>
+      <p>A coverage matrix derived from scope obligations plus methodology disposition gates means every
+        in-scope route and required testing category ends with a disposition — not with silence.</p></div>
+    <div class="card"><h3>Evidence for the report</h3>
+      <p>Findings carry severity, summary, and the signed receipts that authenticate the decisive request and
+        response bytes — the artefact you need at readout, not a screenshot you have to re-earn.</p></div>
+    <div class="card"><h3>Survives a multi-day engagement</h3>
+      <p>PTT tasks, hypotheses, checkpoints, command history, and evidence live in engagement state on disk.
+        Context compression does not reset the assessment; you resume from the checkpoint.</p></div>
+    <div class="card"><h3>Human-in-the-loop by design</h3>
+      <p>Bounded command bursts are reviewed and settled after execution, pending batches can be rebound, and
+        phase transitions require an active task under that phase. The agent proposes; the guard disposes.</p></div>
   </div>
 
-  <div class="flow">
-    <div class="step"><b>1</b>Written authorisation</div><span class="arrow">→</span>
-    <div class="step"><b>2</b>Approved scope</div><span class="arrow">→</span>
-    <div class="step"><b>3</b>Active phase task</div><span class="arrow">→</span>
-    <div class="step"><b>4</b>Guard gates</div><span class="arrow">→</span>
-    <div class="step"><b>5</b>Guarded execution</div><span class="arrow">→</span>
-    <div class="step"><b>6</b>Signed receipt</div><span class="arrow">→</span>
-    <div class="step"><b>7</b>Batch review</div>
+  <div class="cols2" style="margin-top:18px">
+    <div class="yes"><h3>Use it for</h3>
+      <ul>
+        <li>Scoped web, API, identity, business-logic, and LLM-security testing</li>
+        <li>Consultants who need per-finding evidence and a defensible coverage story</li>
+        <li>Teams that want agent leverage without losing the chain of custody</li>
+        <li>Authorised lab, CTF-style, and internal assessment work</li>
+      </ul></div>
+    <div class="no"><h3>Do not use it for</h3>
+      <ul>
+        <li>Anything without written authorisation and an approved scope</li>
+        <li>Unattended mass scanning of hosts you do not own</li>
+        <li>Replacing your judgement on severity, impact, or client context</li>
+        <li>Network isolation — that is your environment's job, not the profile's</li>
+      </ul></div>
   </div>
-
-  <div class="note"><b>Stated plainly:</b> the guard is an execution-boundary control, not network containment.
-    Violin documents this instead of implying otherwise — read the safety model and the benchmark limits before
-    you point it at anything. Use it only against systems you own or are written-authorised to test.</div>
 </div></section>
 
-<section id="tools"><div class="wrap">
-  <h2>Eleven registered tools</h2>
-  <p class="sub">One typed registry, no tool-specific execution adapters, no target allowlists. The
-    <code>violin_exec</code> boundary is the same for every installed non-interactive tool.</p>
-  <table>
-    <tr><th>Tool</th><th>Purpose</th></tr>
-    <tr><td><code>violin_record_ptt</code></td><td>Create, start, refresh, close, or cancel a PTT task</td></tr>
-    <tr><td><code>violin_record_hypothesis</code></td><td>Create or update a scoped hypothesis</td></tr>
-    <tr><td><code>violin_exec</code></td><td>Execute one guarded command</td></tr>
-    <tr><td><code>violin_exec_burst</code></td><td>Execute a bounded command file</td></tr>
-    <tr><td><code>violin_exec_status</code></td><td>Read background execution status</td></tr>
-    <tr><td><code>violin_exec_cancel</code></td><td>Cancel tracked background execution</td></tr>
-    <tr><td><code>violin_review_batch</code></td><td>Review a completed batch and settle state</td></tr>
-    <tr><td><code>violin_rebind_pending_batch</code></td><td>Rebind a pending batch after confirmation</td></tr>
-    <tr><td><code>violin_heartbeat_done</code></td><td>Clear a completed heartbeat review</td></tr>
-    <tr><td><code>violin_target</code></td><td>Resolve the approved assessment target</td></tr>
-    <tr><td><code>violin_status</code></td><td>Explain current tasks, skills, and blockers</td></tr>
+<section id="how"><div class="wrap">
+  <h2>How it works</h2>
+  <p class="sub">Violin does not ask you to trust the model. It asks the guard to answer three questions on
+    every command.</p>
+  <div class="cards">
+    <div class="card"><h3>Is it in scope?</h3>
+      <p>Scope, phase, active PTT task, routed skill, hypothesis binding, and command history are validated
+        before execution. Gates fail closed: a malformed scope denies the command rather than guessing.</p></div>
+    <div class="card"><h3>Can you prove it?</h3>
+      <p>Each passing execution issues a signed receipt covering the command and its decisive response bytes.
+        <code>violin_submit_finding</code> binds the finding to those receipts.</p></div>
+    <div class="card"><h3>Can you resume it?</h3>
+      <p>State is written to the engagement directory as the work happens, so an interrupted or compressed
+        session continues from evidence rather than from re-exploration.</p></div>
+  </div>
+
+  <div class="note" style="margin-top:18px"><b>Stated plainly:</b> the guard is an execution-boundary
+    control, not network containment. The raw-terminal hook is a best-effort safety net. Run Violin in an
+    environment you control, only against systems you own or are written-authorised to test.</div>
+</div></section>
+
+<section id="compare"><div class="wrap">
+  <h2>How the approaches differ</h2>
+  <p class="sub">Agentic pentesting tools differ less in what they can find and more in what they can
+    <em>answer</em> afterwards. This compares design centres, not named products or measured results.</p>
+  <div class="cmp-wrap">
+  <table class="cmp">
+    <tr>
+      <th></th>
+      <th>Autonomous black-box agent</th>
+      <th>General agent with shell access</th>
+      <th>Violin</th>
+    </tr>
+    <tr><td><b>Scope enforcement</b></td>
+      <td>Configured per run; the run is the boundary</td>
+      <td>Whatever the prompt asked for</td>
+      <td>Every command validated against an approved scope file, per command</td></tr>
+    <tr><td><b>Evidence model</b></td>
+      <td>Its own report output</td>
+      <td>Markdown the model wrote</td>
+      <td>Signed receipts; a finding must cite the receipts that prove it</td></tr>
+    <tr><td><b>Coverage</b></td>
+      <td>Whatever the built-in checks covered</td>
+      <td>Usually unrecorded</td>
+      <td>Coverage matrix plus methodology disposition gates, closed out at reporting</td></tr>
+    <tr><td><b>Methodology</b></td>
+      <td>Fixed check set</td>
+      <td>Generic reasoning, per-prompt</td>
+      <td>35 routed playbooks across 7 skills, selected per active task</td></tr>
+    <tr><td><b>State across sessions</b></td>
+      <td>Server-side run record</td>
+      <td>Context window</td>
+      <td>Engagement state on disk: PTT, hypotheses, checkpoints, evidence</td></tr>
+    <tr><td><b>Tool use</b></td>
+      <td>Its own toolset</td>
+      <td>Anything the agent can reach</td>
+      <td>Guard-gated use of the tools already installed in your environment</td></tr>
+    <tr><td><b>Human approval</b></td>
+      <td>Varies by product</td>
+      <td>Prompt-level</td>
+      <td>Bounded bursts, batch review, rebind flow, phase-gated task activation</td></tr>
+    <tr><td><b>Where it runs</b></td>
+      <td>Usually a hosted service</td>
+      <td>Your machine</td>
+      <td>Your machine, your model, no hosted dependency and no profile credentials</td></tr>
   </table>
+  </div>
+  <p class="caption">A checklist you can apply to any tool — including this one — is the point of the
+    <a href="https://github.com/Strategic-Automation/violin/discussions">evaluation discussion</a>.</p>
+</div></section>
+
+<section id="engagement"><div class="wrap">
+  <h2>What an engagement looks like</h2>
+  <p class="sub">One active task, one routed skill, one guarded command boundary, receipts as you go.</p>
+  <ol class="steps">
+    <li><b>Scope first</b>
+      <p>Bootstrap the engagement and approve <code>scope/scope.yaml</code>. Nothing touches the target
+        before this exists, and the coverage matrix is generated from its obligations.</p></li>
+    <li><b>Activate exactly one task</b>
+      <p>Create and start a PTT task under the current phase, naming the routed skill and the concrete
+        technique. Work does not begin a new phase without a task under it.</p></li>
+    <li><b>Run guarded commands</b>
+      <p>Recon through the same boundary as exploitation. A typical recon command through the tool:</p>
+      <pre><span class="c">// one guarded command, resolved against the approved scope</span>
+violin_exec(
+  eng_dir  = "engagements/acme-web",
+  phase    = "RECON",
+  target   = "app.example.com",
+  command  = "nmap -sV -sC -T4 app.example.com -oA quick_app",
+  label    = "service-discovery"
+)
+<span class="c">// gates passed → status: ok, signed execution receipt written</span></pre></li>
+    <li><b>Keep hypotheses honest</b>
+      <p>Hypotheses carry status, confidence, a cheapest test, and kill criteria. Evidence changes their
+        status; a hypothesis that survives without evidence does not become a finding.</p></li>
+    <li><b>Review the batch</b>
+      <p>Bounded bursts are reviewed and settled so state reflects what actually ran, including partial
+        output and failures.</p></li>
+    <li><b>Submit findings that cite receipts</b>
+      <p>Severity, summary, and the decisive evidence. One vulnerability per submission, with the receipts
+        that authenticate the request and response that proved it.</p></li>
+    <li><b>Close out coverage, then report</b>
+      <p>In-scope routes and required testing categories get a disposition — tested, negative evidence, or an
+        explicit exclusion with a reason. Then the report, then the retrospective.</p></li>
+  </ol>
 </div></section>
 
 <section id="playbooks"><div class="wrap">
-  <h2>Routed methodology</h2>
+  <h2>Coverage</h2>
   <p class="sub">35 playbooks across 7 routed skills. An orchestrator selects the focused playbook for the
     capability under test instead of loading one generic checklist.</p>
   <div class="grid">
@@ -252,45 +386,97 @@
   </div>
 </div></section>
 
+<section id="tools"><div class="wrap">
+  <h2>Twelve registered tools</h2>
+  <p class="sub">One typed registry. No tool-specific execution adapters, no target allowlists. The
+    <code>violin_exec</code> boundary is the same for every installed non-interactive tool.</p>
+  <table>
+    <tr><th>Tool</th><th>Purpose</th></tr>
+    <tr><td><code>violin_record_ptt</code></td><td>Create, start, refresh, close, or cancel a PTT task</td></tr>
+    <tr><td><code>violin_record_hypothesis</code></td><td>Create or update a scoped hypothesis</td></tr>
+    <tr><td><code>violin_submit_finding</code></td><td>Submit a validated finding bound to its signed execution receipts</td></tr>
+    <tr><td><code>violin_exec</code></td><td>Execute one guarded command</td></tr>
+    <tr><td><code>violin_exec_burst</code></td><td>Execute a bounded command file</td></tr>
+    <tr><td><code>violin_exec_status</code></td><td>Read background execution status</td></tr>
+    <tr><td><code>violin_exec_cancel</code></td><td>Cancel tracked background execution</td></tr>
+    <tr><td><code>violin_review_batch</code></td><td>Review a completed batch and settle state</td></tr>
+    <tr><td><code>violin_rebind_pending_batch</code></td><td>Rebind a pending batch after confirmation</td></tr>
+    <tr><td><code>violin_heartbeat_done</code></td><td>Clear a completed heartbeat review</td></tr>
+    <tr><td><code>violin_target</code></td><td>Resolve the approved assessment target</td></tr>
+    <tr><td><code>violin_status</code></td><td>Explain current tasks, skills, and blockers</td></tr>
+  </table>
+</div></section>
+
 <section id="limits"><div class="wrap">
   <h2>Honest limits</h2>
-  <p class="sub">Promotional pages usually skip this section. Violin's own documentation does not.</p>
+  <p class="sub">Most tool pages skip this. The project's own documentation does not, so neither does this one.</p>
   <div class="cards">
     <div class="card"><h3>A single run is a noisy sample</h3>
-      <p>Agentic runs vary run to run. The project reports a distribution — mean pass@1, pass@k, pass^k — and
-        prefers the mean over the best run. A repo test pass is not a live benchmark score.</p></div>
+      <p>Agentic runs vary run to run. Violin reports a distribution — mean pass@1, pass@k, pass^k — and
+        prefers the mean to the best run. A repo test pass is not a live benchmark score.</p></div>
     <div class="card"><h3>The guard is not containment</h3>
-      <p>The raw-terminal hook is a best-effort safety net. Network-level containment is your environment's job,
-        not the profile's.</p></div>
+      <p>It constrains what the agent is allowed to run against an approved scope. It does not isolate the
+        network for you.</p></div>
     <div class="card"><h3>No model choices baked in</h3>
-      <p>Violin adds no credentials and selects no model or provider; it inherits whatever Hermes is configured
-        with.</p></div>
-    <div class="card"><h3>Human validation stays</h3>
-      <p>Receipts prove what the tool saw and sent. They do not replace a human judgement call on severity,
-        impact, or whether a finding is worth reporting.</p></div>
+      <p>Violin adds no credentials and selects no provider; it uses your Hermes configuration. Use a capable
+        model — weaker models produce weaker hypotheses, not safer ones.</p></div>
+    <div class="card"><h3>Receipts are not judgement</h3>
+      <p>They prove what was sent and received. Severity, impact, exploitability, and whether a finding
+        belongs in the report remain human calls.</p></div>
   </div>
+</div></section>
+
+<section id="faq"><div class="wrap">
+  <h2>Questions testers actually ask</h2>
+  <details><summary>Does this replace Burp, nmap, or nuclei?</summary>
+    <p>No. It gates and drives the non-interactive tooling already installed in your environment, and keeps
+      the evidence and coverage record. Interactive tooling and your own judgement stay where they are.</p></details>
+  <details><summary>Can it wander out of scope?</summary>
+    <p>The guard denies commands whose resolved target is not in the approved scope, and honouring
+      path-scoped URL exclusions is part of the gates. The raw-terminal hook is a best-effort net rather than
+      containment, so run Violin inside an environment you control.</p></details>
+  <details><summary>Which model should I use?</summary>
+    <p>Whatever your Hermes configuration provides. Violin selects no model and ships no credentials. The
+      README suggests a capable default if you are starting from nothing.</p></details>
+  <details><summary>Can I run it on a live client engagement?</summary>
+    <p>With written authorisation and an approved scope, like any other tooling. You own approvals, target
+      ownership, data handling, and local law. Violin is for authorised assessment only.</p></details>
+  <details><summary>How does a finding get accepted?</summary>
+    <p><code>violin_submit_finding</code> binds the finding to signed receipts that authenticate the decisive
+      request and response bytes. A claim without receipts is a hypothesis, not a finding.</p></details>
+  <details><summary>What does it cost?</summary>
+    <p>Nothing. MIT licensed, no hosted service, no per-target fees, no Violin account.</p></details>
+  <details><summary>Where are the benchmark numbers?</summary>
+    <p>In the methodology, not in a headline. The project publishes how scoring works and explicitly warns
+      against quoting a single run; see <a href="https://github.com/Strategic-Automation/violin/blob/master/docs/BENCHMARKS.md">docs/BENCHMARKS.md</a>.</p></details>
+  <details><summary>How do I ask for a playbook that does not exist?</summary>
+    <p>Open an idea in <a href="https://github.com/Strategic-Automation/violin/discussions">Discussions</a>:
+      name the capability and the obligation a good entry would enforce. Generic capabilities become
+      playbooks; specific targets do not.</p></details>
 </div></section>
 
 <section id="start"><div class="wrap">
   <h2>Quick start</h2>
   <p class="sub">Requirements: Hermes Agent 0.18.0+, a Kali Linux or Parrot OS tool environment, Python 3.11
     and <code>uv</code> for local development, and written authorisation with an approved scope.</p>
-<pre>hermes profile install https://github.com/Strategic-Automation/violin
-hermes -p violin
+<pre>$ hermes profile install https://github.com/Strategic-Automation/violin
+$ hermes -p violin
 
-# then, in the session:
+<span class="c"># then, in the session:</span>
 Run an authorized penetration test against example.com.</pre>
-  <p class="sub">Violin collects scope before any target interaction. Read the
-    <a href="https://github.com/Strategic-Automation/violin#engagement-lifecycle">engagement lifecycle</a> and
+  <p class="sub" style="margin-top:18px">Violin collects scope before any target interaction. Read the
+    <a href="https://github.com/Strategic-Automation/violin#engagement-lifecycle">engagement lifecycle</a>,
     the <a href="https://github.com/Strategic-Automation/violin/blob/master/docs/BENCHMARKS.md">benchmark
-    methodology</a> before your first run.</p>
+    methodology</a>, and the
+    <a href="https://github.com/Strategic-Automation/violin/blob/master/SECURITY.md">security policy</a>
+    before your first run.</p>
 </div></section>
 
 <footer><div class="wrap">
-  <span>MIT licensed · Violin contributors</span>
+  <span>MIT licensed · built for authorised engagements · Violin contributors</span>
   <nav>
     <a href="https://github.com/Strategic-Automation/violin">GitHub</a>
-    <a href="https://github.com/Strategic-Automation/violin/blob/master/SECURITY.md">Security</a>
+    <a href="https://github.com/Strategic-Automation/violin/discussions">Discussions</a>
     <a href="https://github.com/Strategic-Automation/violin/blob/master/CONTRIBUTING.md">Contributing</a>
     <a href="https://hermes-agent.nousresearch.com/">Hermes Agent by Nous Research</a>
   </nav>


### PR DESCRIPTION
## Summary

Practitioner-facing technical documentation and one documentation fix.

### Documentation fix

The plugin registry and plugin.yaml both declare twelve tools. The README tool table omitted violin_submit_finding — the tool that binds a validated finding to its signed execution receipts — and stated the count as eleven. Both the heading and the table are corrected.

### Landing page (docs/index.html)

Rebuilt around how engagements actually run, for working testers rather than a feature list.

### Technical Whitepapers

- docs/articles/ — three operator-facing articles: guardrails for agentic pentesting, coverage discipline, and how to evaluate an agentic pentest tool.

## Verification

- uv run python scripts/violin_guard.py check-release (all checks OK)
- uv run pytest -q (527 passed, 1 skipped)
- uv run ruff check . (All checks passed)