### PR TITLE
fix: explain missing CLI dependencies with recovery commands

### DIFF
--- a/scripts/cli_environment.py
+++ b/scripts/cli_environment.py
@@ -1,0 +1,59 @@
+"""Actionable dependency errors for the standalone diagnostic CLIs."""
+
+from __future__ import annotations
+
+import shlex
+import sys
+from collections.abc import Iterator
+from contextlib import contextmanager
+from pathlib import Path
+
+# Import names for the runtime dependencies declared in pyproject.toml.
+_DEPENDENCY_MODULES = {
+    "bashlex",
+    "cryptography",
+    "duckduckgo_search",
+    "filelock",
+    "netaddr",
+    "psutil",
+    "pydantic",
+    "tirith",
+    "yaml",
+    "yarl",
+}
+
+
+def _format_command(arguments: list[str], *, powershell: bool) -> str:
+    if powershell:
+        # PowerShell single-quoted strings are literal; apostrophes are doubled.
+        return "& " + " ".join("'" + arg.replace("'", "''") + "'" for arg in arguments)
+    return shlex.join(arguments)
+
+
+@contextmanager
+def project_imports(profile_root: Path) -> Iterator[None]:
+    """Explain dependency failures without hiding internal project import errors."""
+    try:
+        yield
+    except ImportError as exc:
+        if not exc.name or exc.name.split(".")[0] not in _DEPENDENCY_MODULES:
+            raise
+        powershell = sys.platform == "win32"
+        command = _format_command(
+            [
+                "uv",
+                "run",
+                "--project",
+                str(profile_root),
+                "python",
+                str(Path(sys.argv[0]).resolve()),
+                *sys.argv[1:],
+            ],
+            powershell=powershell,
+        )
+        shell_hint = " in PowerShell" if powershell else ""
+        raise SystemExit(
+            f"Cannot import a Violin dependency: {exc}\n"
+            f"Current interpreter: {sys.executable}\n"
+            f"Run{shell_hint} with the project environment instead:\n  {command}"
+        ) from None

--- a/scripts/generate-closeout.py
+++ b/scripts/generate-closeout.py
@@ -13,6 +13,8 @@ _PROFILE_ROOT = Path(__file__).resolve().parent.parent
 if str(_PROFILE_ROOT) not in sys.path:
     sys.path.insert(0, str(_PROFILE_ROOT))
 
+from scripts.cli_environment import project_imports
+
 
 def _ensure_venv() -> None:
     try:
@@ -56,9 +58,10 @@ def _ensure_venv() -> None:
                 sys.exit(res.returncode)
 
 
-_ensure_venv()
+with project_imports(_PROFILE_ROOT):
+    _ensure_venv()
 
-from plugins.violin_guard.core import findings  # noqa: E402
+    from plugins.violin_guard.core import findings
 
 
 def main(argv: list[str] | None = None) -> int:

--- a/scripts/violin_guard.py
+++ b/scripts/violin_guard.py
@@ -15,6 +15,8 @@ _PROFILE_ROOT = Path(__file__).resolve().parent.parent
 if str(_PROFILE_ROOT) not in sys.path:
     sys.path.insert(0, str(_PROFILE_ROOT))
 
+from scripts.cli_environment import project_imports
+
 
 def _ensure_venv() -> None:
     try:
@@ -58,12 +60,13 @@ def _ensure_venv() -> None:
                 sys.exit(res.returncode)
 
 
-_ensure_venv()
+with project_imports(_PROFILE_ROOT):
+    _ensure_venv()
 
-from plugins.violin_guard import handlers
-from plugins.violin_guard.core import bootstrap, findings, state
-from plugins.violin_guard.engine import release
-from plugins.violin_guard.gates import command
+    from plugins.violin_guard import handlers
+    from plugins.violin_guard.core import bootstrap, findings, state
+    from plugins.violin_guard.engine import release
+    from plugins.violin_guard.gates import command
 
 
 def _print_result(result) -> int:

--- a/tests/test_cli_surface.py
+++ b/tests/test_cli_surface.py
@@ -2,13 +2,122 @@
 
 from __future__ import annotations
 
+import os
+import shlex
+import shutil
 import subprocess
 import sys
 from pathlib import Path
 
+import pytest
+
+from scripts.cli_environment import _format_command
+
 ROOT = Path(__file__).resolve().parents[1]
 SCRIPT = ROOT / "scripts" / "violin_guard.py"
 SMOKE_SCRIPT = ROOT / "scripts" / "smoke-test.sh"
+
+
+@pytest.mark.parametrize("script_name", ["violin_guard.py", "generate-closeout.py"])
+@pytest.mark.parametrize("missing_module", ["pydantic", "yaml", "plugins.violin_guard.registry"])
+def test_cli_import_failure_diagnostic(script_name: str, missing_module: str) -> None:
+    script = ROOT / "scripts" / script_name
+    # Block imports even if virtualenv discovery adds another site-packages directory.
+    runner = """
+import importlib.abc
+import runpy
+import sys
+from pathlib import Path
+
+missing_module, script, *args = sys.argv[1:]
+
+class MissingDependency(importlib.abc.MetaPathFinder):
+    def find_spec(self, fullname, path=None, target=None):
+        if fullname == missing_module:
+            raise ModuleNotFoundError(f"No module named '{fullname}'", name=fullname)
+
+sys.meta_path.insert(0, MissingDependency())
+sys.path.insert(0, str(Path(script).parent))
+sys.argv = [script, *args]
+runpy.run_path(script, run_name="__main__")
+"""
+    result = subprocess.run(
+        [sys.executable, "-c", runner, missing_module, str(script), "--help"],
+        capture_output=True,
+        text=True,
+        check=False,
+        timeout=15,
+    )
+
+    assert result.returncode == 1
+    assert missing_module in result.stderr
+    if missing_module.startswith("plugins."):
+        assert "Traceback" in result.stderr
+        assert "uv run" not in result.stderr
+    else:
+        assert "Traceback" not in result.stderr
+        assert sys.executable in result.stderr
+        assert (
+            "'uv' 'run' '--project'" in result.stderr
+            if sys.platform == "win32"
+            else "uv run --project" in result.stderr
+        )
+        assert str(script) in result.stderr
+        assert "--help" in result.stderr
+
+
+@pytest.mark.parametrize("script_name", ["violin_guard.py", "generate-closeout.py"])
+def test_cli_without_virtualenv_prints_copyable_command(tmp_path: Path, script_name: str) -> None:
+    checkout = tmp_path / "checkout with spaces"
+    for directory in ("scripts", "plugins"):
+        shutil.copytree(
+            ROOT / directory,
+            checkout / directory,
+            ignore=shutil.ignore_patterns("__pycache__"),
+        )
+    script = checkout / "scripts" / script_name
+    args = ["--eng-dir", "engagement with spaces", "--target", "example.test"]
+    result = subprocess.run(
+        [sys.executable, "-S", str(script), *args],
+        cwd=tmp_path,
+        env={**os.environ, "VIRTUAL_ENV": str(tmp_path / "missing-venv"), "PYTHONPATH": ""},
+        capture_output=True,
+        text=True,
+        check=False,
+        timeout=15,
+    )
+
+    assert result.returncode == 1
+    assert "pydantic" in result.stderr
+    assert "Traceback" not in result.stderr
+    assert sys.executable in result.stderr
+    expected_arguments = [
+        "uv",
+        "run",
+        "--project",
+        str(checkout),
+        "python",
+        str(script),
+        *args,
+    ]
+    command = result.stderr.splitlines()[-1].strip()
+    if sys.platform == "win32":
+        assert "Run in PowerShell" in result.stderr
+        assert command == _format_command(expected_arguments, powershell=True)
+    else:
+        assert shlex.split(command) == expected_arguments
+
+
+def test_recovery_command_quotes_powershell_arguments() -> None:
+    arguments = ["uv", "run", "--project", r"C:\O'Brien\my project", "", "a&b", "$name"]
+    assert _format_command(arguments, powershell=True) == (
+        r"& 'uv' 'run' '--project' 'C:\O''Brien\my project' '' 'a&b' '$name'"
+    )
+
+
+def test_recovery_command_preserves_posix_arguments() -> None:
+    arguments = ["uv", "run", "--project", "/O'Brien/my project", "", "a&b", "$name"]
+    assert shlex.split(_format_command(arguments, powershell=False)) == arguments
 
 
 def test_cli_does_not_advertise_removed_adapter_commands() -> None:


### PR DESCRIPTION
## Summary

Fixes #86.

Keep the existing virtualenv discovery, but show a useful error if a declared dependency still cannot be imported. Both CLI entry points now name the dependency and current interpreter, then print a command to retry with `uv`.

The command keeps the original arguments and working directory, with quoting for POSIX shells or PowerShell. Internal project import errors still show their traceback.

Added regression tests for missing `pydantic`, a partial environment missing `yaml`, no virtualenv, internal import errors, and command quoting.

## Verification

- [x] `uv run pytest` — 538 passed
- [x] `uv run ruff check .`
- [x] `uv run ruff format --check .`
- [x] `uv run python scripts/violin_guard.py check-release`

Tested on macOS with Python 3.11. The full suite and release check ran with networking disabled because an existing integration test attempts a real HTTP request. PowerShell quoting has unit coverage; I haven't run the CLI on Windows locally.

## Documentation and release surfaces

- [x] User-facing behavior and examples match the current code.
- [x] No playbooks added; playbook requirements are not applicable.
- [x] No version, distribution, or skill snapshot changes needed.
- [x] No target data, credentials, engagement evidence, or generated artifacts are included.
