### PR TITLE
fix: repair the playbook filter and correct the receipt fields on the landing page

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -1076,11 +1076,12 @@ violin_exec(
   command = "nmap -sV -sC app.example.com"
 )
 → GATES PASSED (7/7)
-→ Cryptographic receipt issued:
+→ Receipt sealed and signed:
 {
-  "receipt_sha256": "4b7e9a...8f12",
-  "status": "APPROVED",
-  "signature": "ed25519:signed_bytes"
+  "status": "ok",
+  "receipt_hmac_sha256": "9f2c41d8...a7",
+  "receipt_ed25519": "ed25519:MEUCIQDk3f...",
+  "evidence_sha256": ["3b1f8c04..."]
 }</div>
         </div>
       </aside>
@@ -1633,13 +1634,14 @@ violin_exec(
   command = "nmap -sV -sC app.example.com"
 )
 → GATES PASSED (7/7)
-→ Cryptographic receipt written:
+→ Receipt sealed and signed:
 {
-  "receipt_sha256": "4b7e9a...8f12",
-  "status": "APPROVED",
+  "status": "ok",
   "target": "app.example.com",
   "phase": "RECON",
-  "signature": "ed25519:signed_bytes"
+  "receipt_hmac_sha256": "9f2c41d8...a7",
+  "receipt_ed25519": "ed25519:MEUCIQDk3f...",
+  "evidence_sha256": ["3b1f8c04...", "c07a2e91..."]
 }`
     },
     scope_deny: {
@@ -1652,7 +1654,7 @@ violin_exec(
   target  = "internal.corp",
   command = "curl -i https://internal.corp/admin"
 )
-→ GATE 2 FAILURE: VIOLIN-E002 TargetOutOfScope
+→ SCOPE GATE: target resolution failed
 → Target 'internal.corp' not in scope.yaml targets: ['app.example.com']
 → Execution BLOCKED at boundary (fail-closed)
 → Hint: Update scope.yaml or execute against authorized target.`
@@ -1667,7 +1669,7 @@ violin_exec(
   target  = "app.example.com",
   command = "rm -rf /var/log/*"
 )
-→ GATE 7 FAILURE: VIOLIN-E007 DestructiveSafetyPolicy
+→ COMMAND GATE: destructive pattern matched
 → Destructive filesystem payload pattern matched: 'rm -rf'
 → Hard block enforced. No operator bypass allowed.`
     },
@@ -1681,7 +1683,7 @@ violin_exec(
   target  = "app.example.com",
   command = "sqlmap -u 'http://app.example.com/item?id=1' --batch"
 )
-→ GATE 3 FAILURE: VIOLIN-E003 PhaseDesynchronization
+→ PHASE GATE: no active task under that phase
 → Active PTT task is under phase 'RECON', but exploit tool 'sqlmap' requires 'EXPLOITATION'.
 → Denied until an active task under EXPLOITATION is started.`
     }
@@ -1748,6 +1750,9 @@ violin_exec(
   if (searchInput) {
     searchInput.addEventListener('input', updatePlaybooks);
   }
+
+  // Cards ship hidden in CSS so the grid can be filtered; render the initial state.
+  updatePlaybooks();
 </script>
 
 </body>


### PR DESCRIPTION
## Summary

Two defects on the landing page, both verified against the running page and the guard implementation.

### 1. The playbook filter was dead on load

Every `.playbook-card` ships hidden in CSS so the grid can be filtered, but `updatePlaybooks()` was only
bound to the category pills and the search box — it was never called to render the initial state. On the live
page this meant the coverage section showed one card out of 35, clicking a category pill emptied the grid, and
searching returned nothing.

Now the initial state is computed on load. Measured in a browser against `docs/index.html`:

| Interaction | Before | After |
| --- | --- | --- |
| Page load | 1 visible | **35 visible** |
| "Injection (10)" pill | 0 visible | **10 visible** |
| "All (35)" pill | 1 visible | **35 visible** |
| Search `jwt` | 0 visible | **1 visible** (`jwt-attacks`) |
| Clear search | 0 visible | **35 visible** |

### 2. The guard simulator showed fields that do not exist

The hero proof panel and the `recon` scenario displayed a receipt with `receipt_sha256`,
`"status": "APPROVED"` and `"signature": "ed25519:signed_bytes"`, plus denial lines carrying pseudo codes
`VIOLIN-E002 TargetOutOfScope`, `VIOLIN-E003 PhaseDesynchronization`, `VIOLIN-E007 DestructiveSafetyPolicy`.

The implementation disagrees. `plugins/violin_guard/core/receipt_integrity.py` seals records with
`receipt_hmac_sha256`, `receipt_ed25519` and `evidence_sha256`; the execution status vocabulary is
`ok` / `review` / `block` / `denied`; and no `E0xx` identifier scheme exists anywhere in the tree.

On a page whose whole argument is that its claims are verifiable, a reader comparing the demo to the source
finds invented field names. The demo now shows the real sealed fields, the real status vocabulary, and names
the gate that denied instead of inventing an identifier for it.

## Verification

- Rendered `docs/index.html` in a browser and drove the real controls (pills, search box, scenario buttons).
  The table above is measured output, not inspection.
- `grep -c` on the rendered page for `APPROVED`, `receipt_sha256`, `VIOLIN-E0` → all 0.
- No change to the guard, the plugin, the tools, or the profile. Presentation only.
- `uv run python scripts/violin_guard.py check-release` → all checks OK.