### PR TITLE
docs: fix article canonical URLs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,11 @@
 
 ### Fixed
 
+- Articles under `docs/articles/` each carried a duplicate `canonical_url` key, and both YAML and the
+  cross-posting editors take the last one, so every article claimed the repository root as its canonical page
+  instead of its own URL. Each article now declares one canonical URL, pointing at the article.
+- Promotional copy and cover-graphic notes no longer sit inside the published articles; that material moved to
+  `PROMOTION.md`, where the rest of the launch copy lives.
 - README registered-tool list now includes `violin_submit_finding` and states the correct count of twelve.
 
 ### Changed

--- a/PROMOTION.md
+++ b/PROMOTION.md
@@ -480,3 +480,48 @@ Re-read this before every post:
 ---
 
 *End of kit. Before each new platform push, re-verify star count and version from the repo (section 10 references the exact commands) so every post ships accurate numbers.*
+
+## Per-article launch copy
+Material that describes the articles lives here, not inside the published files. Each entry is ready topaste when the piece goes out.
+
+### `docs/articles/coverage-discipline-for-agent-assisted-pentests.md`
+
+Cover graphic spec: Dark technical graphic — a coverage matrix on the left with tested / not_applicable / blocked cells, a scope.yaml obligations list in the centre, and a signed receipt on the right; the three are linked but visibly separate.
+
+```text
+Social (X / LinkedIn): The real failure mode of agent-assisted pentesting is never a missing technique — it is unchecked coverage: an agent that finds three good bugs and silently skips forty owed tests, leaving you unable to tell a client 'tested and clean' from 'never tested'. This article shows a disposition matrix derived from scope obligations, with three enforced states, that stays strictly separate from vulnerability credit.
+Reddit r/netsec / r/cybersecurity title candidates:
+- Your agent found three bugs and skipped forty tests — and you can't tell the difference
+- "Tested and clean" vs "never tested": the coverage problem in agent-assisted pentests
+- The pentest lever agents can't fake: dispositioning every in-scope obligation, not just counting findings
+```
+
+### `docs/articles/guardrails-for-agentic-pentesting.md`
+
+Cover graphic spec: Dark technical cover graphic — a terminal on the left, a signed JSON execution receipt on the right, a clear scope boundary drawn between them.
+
+```text
+Social (X / LinkedIn): Violin is an open-source, Hermes-native agentic pentest profile that puts a required execution guard at the target boundary and binds every finding to a signed execution receipt. It is honest about its limits — no network containment, no model picking, and multi-run benchmark accounting that reports mean pass@1 instead of cherry-picked best runs.
+
+HN title candidates:
+- Agentic pentesting runs on an execution guard and signed receipts
+- Violin: an open-source supervised agentic pentest profile
+- I put a hard guard between an LLM and its pentest target
+- Receipt-backed findings and enforcement for autonomous pentest agents
+- What agentic pentest tooling forgets to demo: proof and scope
+- Violin: a Hermes-native agentic pentester with a fail-closed target guard
+```
+
+### `docs/articles/how-to-evaluate-an-agentic-pentest-tool.md`
+
+Cover graphic spec: Dark technical graphic — a checklist card on the left, a signed JSON execution receipt on the right, and a scope boundary line closing a gap in between. No flags, no trophies.
+
+```text
+Social (X / LinkedIn): Agentic pentesting is demo-rich and evidence-poor. Before you point an agent at a client network, evaluate the accountability layer — one enforced execution boundary, fail-closed gates, signed receipts bound to reproducible findings, and distribution-based benchmarks — not the demo reel. This walkthrough of the controls and a short buyer's checklist is based on Violin, an MIT-licensed, Hermes-native, authorized-only profile: hermes profile install https://github.com/Strategic-Automation/violin
+
+HN title candidates:
+- How to evaluate an agentic pentest tool
+- Agentic pentesting: capability is the easy half, accountability is the job
+- The demo-to-production gap in agentic pentest tooling
+```
+

--- a/docs/articles/coverage-discipline-for-agent-assisted-pentests.md
+++ b/docs/articles/coverage-discipline-for-agent-assisted-pentests.md
@@ -4,8 +4,6 @@ description: Why unchecked coverage is the real failure mode of agent pentesting
 tags: agentic-security, pentesting, methodology, coverage
 canonical_url: https://strategic-automation.github.io/violin/articles/coverage-discipline-for-agent-assisted-pentests.html
 cover_image: https://strategic-automation.github.io/violin/assets/social-preview.png
-canonical_url: https://github.com/Strategic-Automation/violin
-cover_image_note: Dark technical graphic — a coverage matrix on the left with tested / not_applicable / blocked cells, a scope.yaml obligations list in the centre, and a signed receipt on the right; the three are linked but visibly separate.
 ---
 
 # Coverage discipline for agent-assisted pentests
@@ -122,10 +120,3 @@ If you cover this territory professionally — scope negotiation, WSTG category 
 
 https://github.com/Strategic-Automation/violin
 
-<!-- PROMO
-Social (X / LinkedIn): The real failure mode of agent-assisted pentesting is never a missing technique — it is unchecked coverage: an agent that finds three good bugs and silently skips forty owed tests, leaving you unable to tell a client 'tested and clean' from 'never tested'. This article shows a disposition matrix derived from scope obligations, with three enforced states, that stays strictly separate from vulnerability credit.
-Reddit r/netsec / r/cybersecurity title candidates:
-- Your agent found three bugs and skipped forty tests — and you can't tell the difference
-- "Tested and clean" vs "never tested": the coverage problem in agent-assisted pentests
-- The pentest lever agents can't fake: dispositioning every in-scope obligation, not just counting findings
--->

--- a/docs/articles/guardrails-for-agentic-pentesting.md
+++ b/docs/articles/guardrails-for-agentic-pentesting.md
@@ -4,8 +4,6 @@ description: An open-source, Hermes-native agentic pentest profile with a requir
 tags: agentic-security, pentesting, llm-agents, security-tools
 canonical_url: https://strategic-automation.github.io/violin/articles/guardrails-for-agentic-pentesting.html
 cover_image: https://strategic-automation.github.io/violin/assets/social-preview.png
-canonical_url: https://github.com/Strategic-Automation/violin
-cover_image_note: Dark technical cover graphic — a terminal on the left, a signed JSON execution receipt on the right, a clear scope boundary drawn between them.
 ---
 
 # Guardrails for agentic pentesting
@@ -151,14 +149,3 @@ If you want a pentest agent you can actually brief to a client — one whose fin
 
 https://github.com/Strategic-Automation/violin
 
-<!-- PROMO
-Social (X / LinkedIn): Violin is an open-source, Hermes-native agentic pentest profile that puts a required execution guard at the target boundary and binds every finding to a signed execution receipt. It is honest about its limits — no network containment, no model picking, and multi-run benchmark accounting that reports mean pass@1 instead of cherry-picked best runs.
-
-HN title candidates:
-- Agentic pentesting runs on an execution guard and signed receipts
-- Violin: an open-source supervised agentic pentest profile
-- I put a hard guard between an LLM and its pentest target
-- Receipt-backed findings and enforcement for autonomous pentest agents
-- What agentic pentest tooling forgets to demo: proof and scope
-- Violin: a Hermes-native agentic pentester with a fail-closed target guard
--->

--- a/docs/articles/how-to-evaluate-an-agentic-pentest-tool.md
+++ b/docs/articles/how-to-evaluate-an-agentic-pentest-tool.md
@@ -4,8 +4,6 @@ description: Agentic pentesting is demo-rich and evidence-poor. A buyer's checkl
 tags: agentic-security, pentesting, llm-agents, security-evaluation
 canonical_url: https://strategic-automation.github.io/violin/articles/how-to-evaluate-an-agentic-pentest-tool.html
 cover_image: https://strategic-automation.github.io/violin/assets/social-preview.png
-canonical_url: https://github.com/Strategic-Automation/violin
-cover_image_note: Dark technical graphic — a checklist card on the left, a signed JSON execution receipt on the right, and a scope boundary line closing a gap in between. No flags, no trophies.
 ---
 
 # How to evaluate an agentic pentest tool
@@ -79,11 +77,3 @@ hermes -p violin
 
 Violin is MIT-licensed and built for authorized engagements only — you own the scope, the approvals, and the law. If you think a control is wrong, the design is arguable and the discussions are open; the trust model is exactly the part worth arguing about.
 
-<!-- PROMO
-Social (X / LinkedIn): Agentic pentesting is demo-rich and evidence-poor. Before you point an agent at a client network, evaluate the accountability layer — one enforced execution boundary, fail-closed gates, signed receipts bound to reproducible findings, and distribution-based benchmarks — not the demo reel. This walkthrough of the controls and a short buyer's checklist is based on Violin, an MIT-licensed, Hermes-native, authorized-only profile: hermes profile install https://github.com/Strategic-Automation/violin
-
-HN title candidates:
-- How to evaluate an agentic pentest tool
-- Agentic pentesting: capability is the easy half, accountability is the job
-- The demo-to-production gap in agentic pentest tooling
--->

--- a/tests/test_landing_page.py
+++ b/tests/test_landing_page.py
@@ -10,6 +10,8 @@ from __future__ import annotations
 import re
 from pathlib import Path
 
+import yaml
+
 from plugins.violin_guard.core.receipt_integrity import (
     DIGESTS_FIELD,
     PUBLIC_SIGNATURE_FIELD,
@@ -59,3 +61,41 @@ def test_playbook_grid_is_rendered_on_load() -> None:
     assert re.search(r"^\s{0,4}updatePlaybooks\(\);\s*$", page(), re.MULTILINE), (
         "no top-level updatePlaybooks() call: the grid would render empty until a pill is clicked"
     )
+
+
+def articles() -> list[Path]:
+    return sorted((ROOT / "docs" / "articles").glob("*.md"))
+
+
+def front_matter(path: Path) -> str:
+    return path.read_text(encoding="utf-8").split("---", 2)[1]
+
+
+def test_article_front_matter_has_no_duplicate_keys() -> None:
+    """YAML and the cross-posting editors both take the last duplicate key, silently overriding the first."""
+    for path in articles():
+        keys = [
+            line.split(":")[0]
+            for line in front_matter(path).splitlines()
+            if ":" in line and not line.startswith(" ")
+        ]
+        duplicates = {key for key in keys if keys.count(key) > 1}
+
+        assert not duplicates, f"{path.name}: duplicate front-matter keys {duplicates}"
+
+
+def test_article_canonical_url_points_at_the_article() -> None:
+    """A cross-posted copy must point readers at its own page, not the repository root."""
+    for path in articles():
+        canonical = yaml.safe_load(front_matter(path))["canonical_url"]
+
+        assert canonical.endswith(f"/articles/{path.stem}.html"), f"{path.name}: {canonical}"
+
+
+def test_articles_do_not_carry_promotional_material() -> None:
+    """Launch copy belongs in PROMOTION.md, not in the source of what readers are served."""
+    for path in articles():
+        text = path.read_text(encoding="utf-8")
+
+        assert "<!-- PROMO" not in text, f"{path.name} carries a promo block"
+        assert "cover_image_note" not in text, f"{path.name} carries a cover-graphic note"


### PR DESCRIPTION
## Summary

- Removed duplicate `canonical_url` keys from all three practitioner articles.
- Pointed each canonical URL at the article’s own published page.
- Added regression coverage for unique front-matter keys and article-specific canonical URLs.

## Verification

- Full test suite passed before merge.
- Ruff lint and format checks passed.
- Release guard passed.